### PR TITLE
Manage status

### DIFF
--- a/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderstatus_types.go
+++ b/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderstatus_types.go
@@ -13,7 +13,14 @@ import (
 type GCPMachineProviderStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	//TODO(alberto): Populate this and implement status
+
+	// InstanceID is the ID of the instance in GCP
+	// +optional
+	InstanceID *string `json:"instanceId,omitempty"`
+
+	// InstanceState is the provisioning state of the GCP Instance.
+	// +optional
+	InstanceState *string `json:"instanceState,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/gcpprovider/v1beta1/register.go
+++ b/pkg/apis/gcpprovider/v1beta1/register.go
@@ -7,8 +7,14 @@
 package v1beta1
 
 import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -18,3 +24,67 @@ var (
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 )
+
+// RawExtensionFromProviderSpec marshals the machine provider spec.
+func RawExtensionFromProviderSpec(spec *GCPMachineProviderSpec) (*runtime.RawExtension, error) {
+	if spec == nil {
+		return &runtime.RawExtension{}, nil
+	}
+
+	var rawBytes []byte
+	var err error
+	if rawBytes, err = json.Marshal(spec); err != nil {
+		return nil, fmt.Errorf("error marshalling providerSpec: %v", err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+	}, nil
+}
+
+// RawExtensionFromProviderStatus marshals the provider status
+func RawExtensionFromProviderStatus(status *GCPMachineProviderStatus) (*runtime.RawExtension, error) {
+	if status == nil {
+		return &runtime.RawExtension{}, nil
+	}
+
+	var rawBytes []byte
+	var err error
+	if rawBytes, err = json.Marshal(status); err != nil {
+		return nil, fmt.Errorf("error marshalling providerStatus: %v", err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+	}, nil
+}
+
+// ProviderSpecFromRawExtension unmarshals the JSON-encoded spec
+func ProviderSpecFromRawExtension(rawExtension *runtime.RawExtension) (*GCPMachineProviderSpec, error) {
+	if rawExtension == nil {
+		return &GCPMachineProviderSpec{}, nil
+	}
+
+	spec := new(GCPMachineProviderSpec)
+	if err := yaml.Unmarshal(rawExtension.Raw, &spec); err != nil {
+		return nil, fmt.Errorf("error unmarshalling providerSpec: %v", err)
+	}
+
+	klog.V(5).Infof("Got provider spec from raw extension: %+v", spec)
+	return spec, nil
+}
+
+// ProviderStatusFromRawExtension unmarshals a raw extension into a GCPMachineProviderStatus type
+func ProviderStatusFromRawExtension(rawExtension *runtime.RawExtension) (*GCPMachineProviderStatus, error) {
+	if rawExtension == nil {
+		return &GCPMachineProviderStatus{}, nil
+	}
+
+	providerStatus := new(GCPMachineProviderStatus)
+	if err := yaml.Unmarshal(rawExtension.Raw, providerStatus); err != nil {
+		return nil, fmt.Errorf("error unmarshalling providerStatus: %v", err)
+	}
+
+	klog.V(5).Infof("Got provider Status from raw extension: %+v", providerStatus)
+	return providerStatus, nil
+}

--- a/pkg/apis/gcpprovider/v1beta1/register_test.go
+++ b/pkg/apis/gcpprovider/v1beta1/register_test.go
@@ -1,0 +1,81 @@
+package v1beta1
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	expectedProviderSpec = GCPMachineProviderSpec{
+		Zone:         "us-east1-b",
+		MachineType:  "n1-standard-1",
+		Region:       "us-east1",
+		CanIPForward: true,
+		UserDataSecret: &corev1.LocalObjectReference{
+			Name: "myUserData",
+		},
+		NetworkInterfaces: []*GCPNetworkInterface{
+			{
+				Subnetwork: "my-subnet",
+			},
+		},
+	}
+	expectedRawForProviderSpec = `{"metadata":{"creationTimestamp":null},"userDataSecret":{"name":"myUserData"},"canIPForward":true,"deletionProtection":false,"networkInterfaces":[{"subnetwork":"my-subnet"}],"serviceAccounts":null,"machineType":"n1-standard-1","region":"us-east1","zone":"us-east1-b"}`
+
+	instanceID             = "my-instance-id"
+	instanceState          = "RUNNING"
+	expectedProviderStatus = GCPMachineProviderStatus{
+		InstanceID:    &instanceID,
+		InstanceState: &instanceState,
+	}
+	expectedRawForProviderStatus = `{"metadata":{"creationTimestamp":null},"instanceId":"my-instance-id","instanceState":"RUNNING"}`
+)
+
+func TestRawExtensionFromProviderSpec(t *testing.T) {
+	rawExtension, err := RawExtensionFromProviderSpec(&expectedProviderSpec)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if string(rawExtension.Raw) != expectedRawForProviderSpec {
+		t.Errorf("Expected: %s, got: %s", expectedRawForProviderSpec, string(rawExtension.Raw))
+	}
+}
+
+func TestProviderSpecFromRawExtension(t *testing.T) {
+	rawExtension := runtime.RawExtension{
+		Raw: []byte(expectedRawForProviderSpec),
+	}
+	providerSpec, err := ProviderSpecFromRawExtension(&rawExtension)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if reflect.DeepEqual(providerSpec, expectedProviderSpec) {
+		t.Errorf("Expected: %v, got: %v", expectedProviderSpec, providerSpec)
+	}
+}
+
+func TestRawExtensionFromProviderStatus(t *testing.T) {
+	rawExtension, err := RawExtensionFromProviderStatus(&expectedProviderStatus)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if string(rawExtension.Raw) != expectedRawForProviderStatus {
+		t.Errorf("Expected: %s, got: %s", expectedRawForProviderStatus, string(rawExtension.Raw))
+	}
+}
+
+func TestProviderStatusFromRawExtension(t *testing.T) {
+	rawExtension := runtime.RawExtension{
+		Raw: []byte(expectedRawForProviderStatus),
+	}
+	providerStatus, err := ProviderSpecFromRawExtension(&rawExtension)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if reflect.DeepEqual(providerStatus, expectedProviderStatus) {
+		t.Errorf("Expected: %v, got: %v", expectedProviderStatus, providerStatus)
+	}
+}

--- a/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
@@ -141,6 +141,16 @@ func (in *GCPMachineProviderStatus) DeepCopyInto(out *GCPMachineProviderStatus) 
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.InstanceID != nil {
+		in, out := &in.InstanceID, &out.InstanceID
+		*out = new(string)
+		**out = **in
+	}
+	if in.InstanceState != nil {
+		in, out := &in.InstanceState, &out.InstanceState
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cloud/gcp/actuators/machine/actuator.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator.go
@@ -42,6 +42,8 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	if err != nil {
 		return fmt.Errorf("failed to create scope for machine %q: %v", machine.Name, err)
 	}
+	// scope and reconciler lifetime is a machine actuator operation
+	// when scope is closed, it will persist to etcd the given machine spec and machine status (if modified)
 	defer scope.Close()
 	return newReconciler(scope).create()
 }

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -1,11 +1,15 @@
 package machine
 
 import (
+	computeservice "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
+	corev1 "k8s.io/api/core/v1"
+
 	"testing"
 
+	"fmt"
+
 	gcpv1beta1 "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
-	computeservice "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
-	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -13,7 +17,7 @@ import (
 func TestCreate(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
 	machineScope := machineScope{
-		machine: &v1beta1.Machine{
+		machine: &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
 				Namespace: "",
@@ -21,10 +25,67 @@ func TestCreate(t *testing.T) {
 		},
 		coreClient:     controllerfake.NewFakeClient(),
 		providerSpec:   &gcpv1beta1.GCPMachineProviderSpec{},
+		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 		computeService: mockComputeService,
 	}
 	reconciler := newReconciler(&machineScope)
 	if err := reconciler.create(); err != nil {
 		t.Errorf("reconciler was not expected to return error: %v", err)
+	}
+}
+
+func TestReconcileMachineWithCloudState(t *testing.T) {
+	_, mockComputeService := computeservice.NewComputeServiceMock()
+
+	zone := "us-east1-b"
+	projecID := "testProject"
+	instanceName := "testInstance"
+	machineScope := machineScope{
+		machine: &machinev1beta1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceName,
+				Namespace: "",
+			},
+		},
+		coreClient: controllerfake.NewFakeClient(),
+		providerSpec: &gcpv1beta1.GCPMachineProviderSpec{
+			Zone: zone,
+		},
+		projectID:      projecID,
+		providerID:     fmt.Sprintf("gce://%s/%s/%s", projecID, zone, instanceName),
+		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
+		computeService: mockComputeService,
+	}
+
+	expectedNodeAddresses := []corev1.NodeAddress{
+		{
+			Type:    "InternalIP",
+			Address: "10.0.0.15",
+		},
+		{
+			Type:    "ExternalIP",
+			Address: "35.243.147.143",
+		},
+	}
+
+	r := newReconciler(&machineScope)
+	if err := r.reconcileMachineWithCloudState(); err != nil {
+		t.Errorf("reconciler was not expected to return error: %v", err)
+	}
+	if r.machine.Status.Addresses[0] != expectedNodeAddresses[0] {
+		t.Errorf("Expected: %s, got: %s", expectedNodeAddresses[0], r.machine.Status.Addresses[0])
+	}
+	if r.machine.Status.Addresses[1] != expectedNodeAddresses[1] {
+		t.Errorf("Expected: %s, got: %s", expectedNodeAddresses[1], r.machine.Status.Addresses[1])
+	}
+
+	if r.providerID != *r.machine.Spec.ProviderID {
+		t.Errorf("Expected: %s, got: %s", r.providerID, *r.machine.Spec.ProviderID)
+	}
+	if *r.providerStatus.InstanceState != "RUNNING" {
+		t.Errorf("Expected: %s, got: %s", "RUNNING", *r.providerStatus.InstanceState)
+	}
+	if *r.providerStatus.InstanceID != instanceName {
+		t.Errorf("Expected: %s, got: %s", instanceName, *r.providerStatus.InstanceID)
 	}
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -11,6 +11,7 @@ import (
 type GCPComputeService interface {
 	InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error)
+	InstancesGet(project string, zone string, instance string) (*compute.Instance, error)
 }
 
 type computeService struct {
@@ -36,4 +37,9 @@ func (c *computeService) InstancesInsert(project string, zone string, instance *
 // ZoneOperationsGet is a pass through wrapper for compute.Service.ZoneOperations.Get(...)
 func (c *computeService) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
 	return c.service.ZoneOperations.Get(project, zone, operation).Do()
+}
+
+// A pass through wrapper for compute.Service.Instances.Get(...)
+func (c *computeService) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
+	return c.service.Instances.Get(project, zone, instance).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -7,6 +7,7 @@ import (
 type GCPComputeServiceMock struct {
 	mockInstancesInsert   func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	mockZoneOperationsGet func(project string, zone string, operation string) (*compute.Operation, error)
+	mockInstancesGet      func(project string, zone string, instance string) (*compute.Instance, error)
 }
 
 func (c *GCPComputeServiceMock) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
@@ -21,6 +22,26 @@ func (c *GCPComputeServiceMock) ZoneOperationsGet(project string, zone string, o
 		return nil, nil
 	}
 	return c.mockZoneOperationsGet(project, zone, operation)
+}
+
+func (c *GCPComputeServiceMock) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
+	return &compute.Instance{
+		Name:         instance,
+		Zone:         zone,
+		MachineType:  "n1-standard-1",
+		CanIpForward: true,
+		NetworkInterfaces: []*compute.NetworkInterface{
+			{
+				NetworkIP: "10.0.0.15",
+				AccessConfigs: []*compute.AccessConfig{
+					{
+						NatIP: "35.243.147.143",
+					},
+				},
+			},
+		},
+		Status: "RUNNING",
+	}, nil
 }
 
 func NewComputeServiceMock() (*compute.Instance, *GCPComputeServiceMock) {


### PR DESCRIPTION
- Add status API types
- Create proper struct type <-> rawExtension methods and tests for providerSpec and providerStatus
- Add providerID and providerStatus to machine scope and use new struct type <-> rawExtension methods
- Add reconcileMachineWithCloudState() to be called on Create for now