### PR TITLE
Make create and delete async operations

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -200,13 +200,6 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 		r.machine.Status.Addresses = nodeAddresses
 		r.providerStatus.InstanceState = &freshInstance.Status
 		r.providerStatus.InstanceID = &freshInstance.Name
-		succeedCondition := v1beta1.GCPMachineProviderCondition{
-			Type:    v1beta1.MachineCreated,
-			Reason:  machineCreationSucceedReason,
-			Message: machineCreationSucceedMessage,
-			Status:  corev1.ConditionTrue,
-		}
-		r.providerStatus.Conditions = reconcileProviderConditions(r.providerStatus.Conditions, succeedCondition)
 	}
 	return nil
 }

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	gcpv1beta1 "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	computeservice "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
 	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	clusterapifake "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -14,17 +15,23 @@ import (
 
 func TestCreate(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
-	machineScope := machineScope{
-		machine: &machinev1beta1.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "",
-				Namespace: "",
-			},
+
+	machine := machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gcp",
+			Namespace: "test",
 		},
+	}
+
+	cs := clusterapifake.NewSimpleClientset(&machine)
+
+	machineScope := machineScope{
+		machine:        &machine,
 		coreClient:     controllerfake.NewFakeClient(),
 		providerSpec:   &gcpv1beta1.GCPMachineProviderSpec{},
 		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 		computeService: mockComputeService,
+		machineClient:  cs.MachineV1beta1().Machines(machine.Namespace),
 	}
 	reconciler := newReconciler(&machineScope)
 	if err := reconciler.create(); err != nil {
@@ -41,6 +48,13 @@ func TestCreate(t *testing.T) {
 	}
 	if reconciler.providerStatus.Conditions[0].Message != machineCreationSucceedMessage {
 		t.Errorf("Expected: %s, got %s", machineCreationSucceedMessage, reconciler.providerStatus.Conditions[0].Message)
+	}
+	exists, err := reconciler.exists()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Errorf("expected machine to exist, got %t", exists)
 	}
 }
 
@@ -100,7 +114,7 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 	}
 }
 
-func TestExists(t *testing.T) {
+func TestExistsFails(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
 	machineScope := machineScope{
 		machine: &machinev1beta1.Machine{
@@ -116,7 +130,8 @@ func TestExists(t *testing.T) {
 	}
 	reconciler := newReconciler(&machineScope)
 	exists, err := reconciler.exists()
-	if err != nil || exists != true {
+	// No machine exists or was created, so expecting false.
+	if err != nil || exists {
 		t.Errorf("reconciler was not expected to return error: %v", err)
 	}
 }

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	gcpv1beta1 "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	computeservice "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
 	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	clusterapifake "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -20,6 +22,7 @@ func TestCreate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gcp",
 			Namespace: "test",
+			UID:       types.UID(uuid.New().String()),
 		},
 	}
 

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -9,7 +9,7 @@ import (
 // GCPComputeService is a pass through wrapper for google.golang.org/api/compute/v1/compute
 // to enable tests to mock this struct and control behavior.
 type GCPComputeService interface {
-	InstancesDelete(project string, zone string, instance string) (*compute.Operation, error)
+	InstancesDelete(requestID string, project string, zone string, instance string) (*compute.Operation, error)
 	InstancesInsert(requestID string, project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	InstancesGet(project string, zone string, instance string) (*compute.Instance, error)
 	ZonesGet(project string, zone string) (*compute.Zone, error)
@@ -45,8 +45,8 @@ func (c *computeService) InstancesGet(project string, zone string, instance stri
 	return c.service.Instances.Get(project, zone, instance).Do()
 }
 
-func (c *computeService) InstancesDelete(project string, zone string, instance string) (*compute.Operation, error) {
-	return c.service.Instances.Delete(project, zone, instance).Do()
+func (c *computeService) InstancesDelete(requestId string, project string, zone string, instance string) (*compute.Operation, error) {
+	return c.service.Instances.Delete(project, zone, instance).RequestId(requestId).Do()
 }
 
 func (c *computeService) ZonesGet(project string, zone string) (*compute.Zone, error) {

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -1,15 +1,16 @@
 package computeservice
 
 import (
-	"google.golang.org/api/compute/v1"
 	"net/http"
+
+	"google.golang.org/api/compute/v1"
 )
 
 // GCPComputeService is a pass through wrapper for google.golang.org/api/compute/v1/compute
 // to enable tests to mock this struct and control behavior.
 type GCPComputeService interface {
 	InstancesDelete(project string, zone string, instance string) (*compute.Operation, error)
-	InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+	InstancesInsert(requestID string, project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	InstancesGet(project string, zone string, instance string) (*compute.Instance, error)
 	ZonesGet(project string, zone string) (*compute.Zone, error)
 	ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error)
@@ -31,8 +32,8 @@ func NewComputeService(oauthClient *http.Client) (*computeService, error) {
 }
 
 // InstancesInsert is a pass through wrapper for compute.Service.Instances.Insert(...)
-func (c *computeService) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
-	return c.service.Instances.Insert(project, zone, instance).Do()
+func (c *computeService) InstancesInsert(requestID, project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+	return c.service.Instances.Insert(project, zone, instance).RequestId(requestID).Do()
 }
 
 // ZoneOperationsGet is a pass through wrapper for compute.Service.ZoneOperations.Get(...)

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -5,16 +5,16 @@ import (
 )
 
 type GCPComputeServiceMock struct {
-	mockInstancesInsert   func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+	mockInstancesInsert   func(requestId string, project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	mockZoneOperationsGet func(project string, zone string, operation string) (*compute.Operation, error)
 	mockInstancesGet      func(project string, zone string, instance string) (*compute.Instance, error)
 }
 
-func (c *GCPComputeServiceMock) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+func (c *GCPComputeServiceMock) InstancesInsert(requestId, project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
 	if c.mockInstancesInsert == nil {
 		return nil, nil
 	}
-	return c.mockInstancesInsert(project, zone, instance)
+	return c.mockInstancesInsert(requestId, project, zone, instance)
 }
 
 func (c *GCPComputeServiceMock) InstancesDelete(project string, zone string, instance string) (*compute.Operation, error) {
@@ -57,7 +57,7 @@ func (c *GCPComputeServiceMock) ZonesGet(project string, zone string) (*compute.
 func NewComputeServiceMock() (*compute.Instance, *GCPComputeServiceMock) {
 	var receivedInstance compute.Instance
 	computeServiceMock := GCPComputeServiceMock{
-		mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+		mockInstancesInsert: func(_, project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
 			receivedInstance = *instance
 			return &compute.Operation{
 				Status: "DONE",

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -17,7 +17,7 @@ func (c *GCPComputeServiceMock) InstancesInsert(requestId, project string, zone 
 	return c.mockInstancesInsert(requestId, project, zone, instance)
 }
 
-func (c *GCPComputeServiceMock) InstancesDelete(project string, zone string, instance string) (*compute.Operation, error) {
+func (c *GCPComputeServiceMock) InstancesDelete(requestId string, project string, zone string, instance string) (*compute.Operation, error) {
 	return &compute.Operation{
 		Status: "DONE",
 	}, nil


### PR DESCRIPTION
The previous behaviour for create was to block until the create operation was _"DONE"_.

This changes the overall behaviour of `create()` to be an asynchronous / idempotent call. If you pass a `UID` as an additional request parameter to `computeservice.InsertInstances()` then, as long as all the other parameters are equal (i.e., project, zone, name), this then becomes an idempotent call.

The create sequence is now:
- create instance from scope
- call `InstancesInsert` with instance
- check to see if operation is _"DONE"_
- requeue operation if not _"DONE"_
- when done, update spec
- when done, update status with created condition

The sentinel value for `exists()` now changes to:
- instance exists, and
- created condition exists on machine status

After a successful create, update will be called naturally - naturally because create would have modified the machine object, the `controller.Reconcile()` loop will trigger again (as part of the informer update on the machine object), and during this pass `exists()` will be `true`, so `update()` will be called.

Also:
- Updated the unit tests to reflect and handle the new async behaviour.
- The `MachineCreated` condition is now only set once create concludes