### PR TITLE
actuator: make create and delete asynchronous operations

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/actuator.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator.go
@@ -49,7 +49,6 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	if err != nil {
 		return fmt.Errorf(scopeFailFmt, machine.Name, err)
 	}
-	defer scope.Close()
 	return newReconciler(scope).create()
 }
 
@@ -63,11 +62,6 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 	if err != nil {
 		return false, fmt.Errorf(scopeFailFmt, machine.Name, err)
 	}
-	// The core machine controller calls exists() + create()/update() in the same reconciling operation.
-	// If exists() would store machineSpec/status object then create()/update() would still receive the local version.
-	// When create()/update() try to store machineSpec/status this might result in
-	// "Operation cannot be fulfilled; the object has been modified; please apply your changes to the latest version and try again."
-	// Therefore we don't close the scope here and we only store spec/status atomically either in create()/update()"
 	return newReconciler(scope).exists()
 }
 
@@ -81,7 +75,6 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	if err != nil {
 		return fmt.Errorf("failed to create scope for machine %q: %v", machine.Name, err)
 	}
-	defer scope.Close()
 	return newReconciler(scope).update()
 }
 

--- a/pkg/cloud/gcp/actuators/machine/conditions.go
+++ b/pkg/cloud/gcp/actuators/machine/conditions.go
@@ -33,7 +33,7 @@ func shouldUpdateCondition(
 // 1) Requested Status is different than existing status.
 // 2) requested Reason is different that existing one.
 // 3) requested Message is different that existing one.
-func reconcileProviderConditions(conditions []v1beta1.GCPMachineProviderCondition, newCondition v1beta1.GCPMachineProviderCondition) []v1beta1.GCPMachineProviderCondition {
+func setProviderConditions(conditions []v1beta1.GCPMachineProviderCondition, newCondition v1beta1.GCPMachineProviderCondition) []v1beta1.GCPMachineProviderCondition {
 	now := metav1.Now()
 	currentCondition := findCondition(conditions, newCondition.Type)
 	if currentCondition == nil {

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -14,15 +14,12 @@ import (
 	apicorev1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	userDataSecretKey  = "userData"
-	operationTimeOut   = 180 * time.Second
-	operationRetryWait = 5 * time.Second
+	userDataSecretKey = "userData"
 	pendingCreateKey  = "machine.openshift.io/cluster-api-provider-gcp-CREATE-ID"
 	pendingDeleteKey  = "machine.openshift.io/cluster-api-provider-gcp-DELETE-ID"
 	requeuePeriod     = 20 * time.Second
@@ -231,7 +228,6 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 	}
 	return nil
 }
-
 func (r *Reconciler) getCustomUserData() (string, error) {
 	if r.providerSpec.UserDataSecret == nil {
 		return "", nil
@@ -246,29 +242,6 @@ func (r *Reconciler) getCustomUserData() (string, error) {
 		return "", fmt.Errorf("secret %v/%v does not have %q field set. Thus, no user data applied when creating an instance", r.machine.GetNamespace(), r.providerSpec.UserDataSecret.Name, userDataSecretKey)
 	}
 	return base64.StdEncoding.EncodeToString(data), nil
-}
-
-func (r *Reconciler) waitUntilOperationCompleted(zone, operationName string) (*compute.Operation, error) {
-	var op *compute.Operation
-	var err error
-	return op, wait.Poll(operationRetryWait, operationTimeOut, func() (bool, error) {
-		op, err = r.computeService.ZoneOperationsGet(r.projectID, zone, operationName)
-		if err != nil {
-			return false, err
-		}
-		klog.V(3).Infof("Waiting for %q operation to be completed... (status: %s)", op.OperationType, op.Status)
-		if op.Status == "DONE" {
-			if op.Error == nil {
-				return true, nil
-			}
-			var err []error
-			for _, opErr := range op.Error.Errors {
-				err = append(err, fmt.Errorf("%s", *opErr))
-			}
-			return false, fmt.Errorf("the following errors occurred: %+v", err)
-		}
-		return false, nil
-	})
 }
 
 func validateMachine(machine machinev1.Machine, providerSpec v1beta1.GCPMachineProviderSpec) error {

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -170,11 +170,16 @@ func (r *Reconciler) create() error {
 	}
 
 	delete(r.machine.Annotations, pendingCreateKey)
-	return nil
+	_, err = r.persist()
+	return err
 }
 
 func (r *Reconciler) update() error {
-	return r.reconcileMachineWithCloudState(nil)
+	if err := r.reconcileMachineWithCloudState(nil); err != nil {
+		return err
+	}
+	_, err := r.persist()
+	return err
 }
 
 // reconcileMachineWithCloudState reconcile machineSpec and status with the latest cloud state
@@ -228,6 +233,7 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 	}
 	return nil
 }
+
 func (r *Reconciler) getCustomUserData() (string, error) {
 	if r.providerSpec.UserDataSecret == nil {
 		return "", nil
@@ -295,7 +301,8 @@ func (r *Reconciler) delete() error {
 		return &clustererror.RequeueAfterError{RequeueAfter: requeuePeriod}
 	}
 	delete(r.machine.Annotations, pendingDeleteKey)
-	return nil
+	_, err = r.persist()
+	return err
 }
 
 func (r *Reconciler) validateZone() error {

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -93,7 +93,7 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 	}
 
 	r := newReconciler(&machineScope)
-	if err := r.reconcileMachineWithCloudState(nil); err != nil {
+	if err := r.reconcileMachineWithCloudState(); err != nil {
 		t.Errorf("reconciler was not expected to return error: %v", err)
 	}
 	if r.machine.Status.Addresses[0] != expectedNodeAddresses[0] {

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -137,17 +137,23 @@ func TestExists(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
-	machineScope := machineScope{
-		machine: &machinev1beta1.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "",
-				Namespace: "",
-			},
+
+	machine := machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gcp",
+			Namespace: "test",
 		},
+	}
+
+	cs := clusterapifake.NewSimpleClientset(&machine)
+
+	machineScope := machineScope{
+		machine:        &machine,
 		coreClient:     controllerfake.NewFakeClient(),
 		providerSpec:   &gcpv1beta1.GCPMachineProviderSpec{},
 		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 		computeService: mockComputeService,
+		machineClient:  cs.MachineV1beta1().Machines(machine.Namespace),
 	}
 	reconciler := newReconciler(&machineScope)
 	if err := reconciler.delete(); err != nil {


### PR DESCRIPTION
The previous behaviour for `Reconciler.create()` and `Reconciler.delete()` was to block until their respective operations were complete. This change modifies both create() and delete() to be asynchronous operations. Each method returns a `RequeueRequestError()` until the underlying GCP cloud operations are marked as _DONE_.