### PR TITLE
reconciler: change exists to consider TERMINATED state only

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -256,12 +256,12 @@ func (r *Reconciler) exists() (bool, error) {
 	instance, err := r.computeService.InstancesGet(r.projectID, zone, r.machine.Name)
 	if err == nil {
 		switch instance.Status {
-		case "PROVISIONING", "REPAIRING", "RUNNING", "STAGING":
-			klog.Infof("Machine %q already exists", r.machine.Name)
-			return true, nil
-		default:
+		case "TERMINATED":
 			klog.Infof("Machine %q is considered as non existent as its status is %q", instance.Status)
 			return false, nil
+		default:
+			klog.Infof("Machine %q already exists", r.machine.Name)
+			return true, nil
 		}
 	}
 	if isNotFoundError(err) {


### PR DESCRIPTION
This inverts the behaviour of reconciler.exists() to only consider the
TERMINATED state when determining if the instance exists, or not.