### PR TITLE
Add e2e make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ build: ## build binaries
                -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/manager"
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/manager -ldflags '-extldflags -static' \
                "$(REPO_PATH)/vendor/github.com/openshift/cluster-api/cmd/manager"
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests
+	hack/e2e.sh

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+GOPATH="$(mktemp -d)"
+export GOPATH
+
+ACTUATOR_PKG="github.com/openshift/cluster-api-actuator-pkg"
+
+go get -u -d "${ACTUATOR_PKG}/..."
+
+exec make --directory="${GOPATH}/src/${ACTUATOR_PKG}" test-e2e


### PR DESCRIPTION
This commit adds e2e test to Makefile.  This test
will clone cluster-api-actuator-pkg and run tests
from that clone.