### PR TITLE
Prepend machine.Name to logging

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/actuator.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	scopeFailFmt      = "failed to create scope for machine %q: %v"
+	scopeFailFmt      = "%s: failed to create scope for machine: %v"
 	createEventAction = "Create"
 	updateEventAction = "Update"
 	deleteEventAction = "Delete"
@@ -55,13 +55,13 @@ func (a *Actuator) handleMachineError(machine *machinev1.Machine, err *apierrors
 		a.eventRecorder.Eventf(machine, corev1.EventTypeWarning, "Failed"+eventAction, "%v", err.Reason)
 	}
 
-	klog.Errorf("Machine error: %v", err.Message)
+	klog.Errorf("%s: Machine error: %v", machine.Name, err.Message)
 	return err
 }
 
 // Create creates a machine and is invoked by the machine controller.
 func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) error {
-	klog.Infof("Creating machine %q", machine.Name)
+	klog.Infof("%s: Creating machine", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
 		machineClient: a.machineClient,
 		coreClient:    a.coreClient,
@@ -80,7 +80,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 }
 
 func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) (bool, error) {
-	klog.Infof("Checking if machine %q exists", machine.Name)
+	klog.Infof("%s: Checking if machine exists", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
 		machineClient: a.machineClient,
 		coreClient:    a.coreClient,
@@ -98,7 +98,7 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 }
 
 func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) error {
-	klog.Infof("Updating machine %q", machine.Name)
+	klog.Infof("%s: Updating machine", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
 		machineClient: a.machineClient,
 		coreClient:    a.coreClient,
@@ -117,7 +117,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 }
 
 func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) error {
-	klog.Infof("Deleting machine %v", machine.Name)
+	klog.Infof("%s: Deleting machine", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
 		machineClient: a.machineClient,
 		coreClient:    a.coreClient,

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -139,7 +139,7 @@ func (r *Reconciler) update() error {
 // if a failedCondition is passed it updates the providerStatus.Conditions and return
 // otherwise it fetches the relevant cloud instance and reconcile the rest of the fields
 func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCPMachineProviderCondition) error {
-	klog.Infof("Reconciling machine object %q with cloud state", r.machine.Name)
+	klog.Infof("%s: Reconciling machine object with cloud state", r.machine.Name)
 	if failedCondition != nil {
 		r.providerStatus.Conditions = reconcileProviderConditions(r.providerStatus.Conditions, *failedCondition)
 		return nil
@@ -185,7 +185,7 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 		r.providerStatus.Conditions = reconcileProviderConditions(r.providerStatus.Conditions, succeedCondition)
 
 		if freshInstance.Status != "RUNNING" {
-			klog.Infof("machine %q status is %q, requeuing...", r.machine.Name, freshInstance.Status)
+			klog.Infof("%s: machine status is %q, requeuing...", r.machine.Name, freshInstance.Status)
 			return &clustererror.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}
 	}
@@ -239,7 +239,7 @@ func (r *Reconciler) exists() (bool, error) {
 		}
 	}
 	if isNotFoundError(err) {
-		klog.Infof("Machine %q does not exist", r.machine.Name)
+		klog.Infof("%s: Machine does not exist", r.machine.Name)
 		return false, nil
 	}
 	return false, fmt.Errorf("error getting running instances: %v", err)
@@ -252,13 +252,13 @@ func (r *Reconciler) delete() error {
 		return err
 	}
 	if !exists {
-		klog.Infof("Machine %v not found during delete, skipping", r.machine.Name)
+		klog.Infof("%s: Machine not found during delete, skipping", r.machine.Name)
 		return nil
 	}
 	if _, err = r.computeService.InstancesDelete(string(r.machine.UID), r.projectID, r.providerSpec.Zone, r.machine.Name); err != nil {
 		return fmt.Errorf("failed to delete instance via compute service: %v", err)
 	}
-	klog.Infof("machine %q status is exists, requeuing...", r.machine.Name)
+	klog.Infof("%s: machine status is exists, requeuing...", r.machine.Name)
 	return &clustererror.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 }
 


### PR DESCRIPTION
This commit adds machine.Name to most logging
to enable easier troubleshooting of logs with
grep.