### PR TITLE
Fix name of the credentials key

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/machine_scope.go
+++ b/pkg/cloud/gcp/actuators/machine/machine_scope.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	credentialsSecretKey = "serviceAccountJSON"
+	credentialsSecretKey = "service_account.json"
 )
 
 // machineScopeParams defines the input parameters used to create a new MachineScope.


### PR DESCRIPTION
With https://github.com/openshift/cloud-credential-operator/pull/92, the credential key used by the cloud creds operator will be `service_account.json`