### PR TITLE
Allow specifying whether you want a public IP

### DIFF
--- a/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -59,6 +59,7 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
+	PublicIP   bool   `json:"publicIP,omitempty"`
 	Network    string `json:"network,omitempty"`
 	Subnetwork string `json:"subnetwork,omitempty"`
 }

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -71,9 +71,14 @@ func (r *Reconciler) create() error {
 
 	// networking
 	var networkInterfaces = []*compute.NetworkInterface{}
+
 	for _, nic := range r.providerSpec.NetworkInterfaces {
+		accessConfigs := []*compute.AccessConfig{}
+		if nic.PublicIP {
+			accessConfigs = append(accessConfigs, &compute.AccessConfig{})
+		}
 		computeNIC := &compute.NetworkInterface{
-			AccessConfigs: []*compute.AccessConfig{{}},
+			AccessConfigs: accessConfigs,
 		}
 		if len(nic.Network) != 0 {
 			computeNIC.Network = fmt.Sprintf("projects/%s/global/networks/%s", r.projectID, nic.Network)


### PR DESCRIPTION
Currently a public IP is generated for every network interface in a machine (by specifying a non-empty AccessConfig). This PR introduces a boolean to allow you to specify whether a public IP is needed. For OCP use cases it's not.