### PR TITLE
Pass full URL to image when creating compute instance

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -63,7 +63,7 @@ func (r *Reconciler) create() error {
 				DiskSizeGb:  disk.SizeGb,
 				DiskType:    fmt.Sprintf("zones/%s/diskTypes/%s", zone, disk.Type),
 				Labels:      disk.Labels,
-				SourceImage: disk.Image,
+				SourceImage: googleapi.ResolveRelative(r.computeService.BasePath(), fmt.Sprintf("%s/global/images/%s", r.projectID, disk.Image)),
 			},
 		})
 	}

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -14,6 +14,7 @@ type GCPComputeService interface {
 	InstancesGet(project string, zone string, instance string) (*compute.Instance, error)
 	ZonesGet(project string, zone string) (*compute.Zone, error)
 	ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error)
+	BasePath() string
 }
 
 type computeService struct {
@@ -51,4 +52,8 @@ func (c *computeService) InstancesDelete(requestId string, project string, zone 
 
 func (c *computeService) ZonesGet(project string, zone string) (*compute.Zone, error) {
 	return c.service.Zones.Get(project, zone).Do()
+}
+
+func (c *computeService) BasePath() string {
+	return c.service.BasePath
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -54,6 +54,10 @@ func (c *GCPComputeServiceMock) ZonesGet(project string, zone string) (*compute.
 	return nil, nil
 }
 
+func (c *GCPComputeServiceMock) BasePath() string {
+	return "path/"
+}
+
 func NewComputeServiceMock() (*compute.Instance, *GCPComputeServiceMock) {
 	var receivedInstance compute.Instance
 	computeServiceMock := GCPComputeServiceMock{


### PR DESCRIPTION
The image parameter must be in the form:
https://www.googleapis.com/compute/v1/projects/{project}/global/images/{image}