### PR TITLE
Use the same type for both internal addresses

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -172,7 +172,7 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 		})
 		// [INSTANCE_NAME].c.[PROJECT_ID].internal
 		nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
-			Type:    "AltInternalDNS",
+			Type:    corev1.NodeInternalDNS,
 			Address: fmt.Sprintf("%s.c.%s.internal", r.machine.Name, r.projectID),
 		})
 


### PR DESCRIPTION
Instead of introducing a different key for the alternate internal DNS,
simply use the same key that is already part of the core API. The CSR
approver will use either address to approve a machine request.