### PR TITLE
Add support for TargetPools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ OpenShift [machine-api](https://github.com/openshift/cluster-api).
 
 This provider runs as a machine-controller deployed by the
 [machine-api-operator](https://github.com/openshift/machine-api-operator)
+
+## TargetPools
+Target pools exist in a *region*
+
+Regions have multiple *zones*
+
+Instances associated with Target Pools must be in the same *region* as
+the target pool.

--- a/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -30,6 +30,7 @@ type GCPMachineProviderSpec struct {
 	NetworkInterfaces  []*GCPNetworkInterface `json:"networkInterfaces,omitempty"`
 	ServiceAccounts    []GCPServiceAccount    `json:"serviceAccounts"`
 	Tags               []string               `json:"tags,omitempty"`
+	TargetPools        []string               `json:"targetPools,omitempty"`
 	MachineType        string                 `json:"machineType"`
 	Region             string                 `json:"region"`
 	Zone               string                 `json:"zone"`

--- a/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
@@ -133,6 +133,11 @@ func (in *GCPMachineProviderSpec) DeepCopyInto(out *GCPMachineProviderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TargetPools != nil {
+		in, out := &in.TargetPools, &out.TargetPools
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -15,6 +15,9 @@ type GCPComputeService interface {
 	ZonesGet(project string, zone string) (*compute.Zone, error)
 	ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error)
 	BasePath() string
+	TargetPoolsGet(project string, region string, name string) (*compute.TargetPool, error)
+	TargetPoolsAddInstance(project string, region string, name string, instance string) (*compute.Operation, error)
+	TargetPoolsRemoveInstance(project string, region string, name string, instance string) (*compute.Operation, error)
 }
 
 type computeService struct {
@@ -56,4 +59,30 @@ func (c *computeService) ZonesGet(project string, zone string) (*compute.Zone, e
 
 func (c *computeService) BasePath() string {
 	return c.service.BasePath
+}
+
+func (c *computeService) TargetPoolsGet(project string, region string, name string) (*compute.TargetPool, error) {
+	return c.service.TargetPools.Get(project, region, name).Do()
+}
+
+func (c *computeService) TargetPoolsAddInstance(project string, region string, name string, instanceLink string) (*compute.Operation, error) {
+	rb := &compute.TargetPoolsAddInstanceRequest{
+		Instances: []*compute.InstanceReference{
+			{
+				Instance: instanceLink,
+			},
+		},
+	}
+	return c.service.TargetPools.AddInstance(project, region, name, rb).Do()
+}
+
+func (c *computeService) TargetPoolsRemoveInstance(project string, region string, name string, instanceLink string) (*compute.Operation, error) {
+	rb := &compute.TargetPoolsRemoveInstanceRequest{
+		Instances: []*compute.InstanceReference{
+			{
+				Instance: instanceLink,
+			},
+		},
+	}
+	return c.service.TargetPools.RemoveInstance(project, region, name, rb).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -4,6 +4,11 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
+const (
+	NoMachinesInPool  = "NoMachinesInPool"
+	WithMachineInPool = "WithMachineInPool"
+)
+
 type GCPComputeServiceMock struct {
 	mockInstancesInsert   func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	mockZoneOperationsGet func(project string, zone string, operation string) (*compute.Operation, error)
@@ -56,6 +61,28 @@ func (c *GCPComputeServiceMock) ZonesGet(project string, zone string) (*compute.
 
 func (c *GCPComputeServiceMock) BasePath() string {
 	return "path/"
+}
+
+func (c *GCPComputeServiceMock) TargetPoolsGet(project string, region string, name string) (*compute.TargetPool, error) {
+	if region == NoMachinesInPool {
+		return &compute.TargetPool{}, nil
+	}
+	if region == WithMachineInPool {
+		return &compute.TargetPool{
+			Instances: []string{
+				"https://www.googleapis.com/compute/v1/projects/testProject/zones/zone1/instances/testInstance",
+			},
+		}, nil
+	}
+	return nil, nil
+}
+
+func (c *GCPComputeServiceMock) TargetPoolsAddInstance(project string, region string, name string, instance string) (*compute.Operation, error) {
+	return nil, nil
+}
+
+func (c *GCPComputeServiceMock) TargetPoolsRemoveInstance(project string, region string, name string, instance string) (*compute.Operation, error) {
+	return nil, nil
 }
 
 func NewComputeServiceMock() (*compute.Instance, *GCPComputeServiceMock) {


### PR DESCRIPTION
This commit extends the providerSpec to add the field
TargetPools, which is a list of strings specifying
targetpools you wish to add the instance to.

This commit supports removing the instance from a
target pool when the machine-object is deleted.

This commit also adds unit tests.

The target pools must already exist for this to work, similiar to AWS LB's.
 If we don't have this PR, masters won't be added to the appropriate LB's when doing disaster recovery.