### PR TITLE
Return errors from scope.Close()

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/actuator.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator.go
@@ -71,12 +71,11 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		fmtErr := fmt.Sprintf(scopeFailFmt, machine.Name, err)
 		return a.handleMachineError(machine, apierrors.CreateMachine(fmtErr), createEventAction)
 	}
-	defer scope.Close()
 	if err := newReconciler(scope).create(); err != nil {
 		return a.handleMachineError(machine, apierrors.CreateMachine(err.Error()), createEventAction)
 	}
 	a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, createEventAction, "Created Machine %v", machine.Name)
-	return nil
+	return scope.Close()
 }
 
 func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) (bool, error) {
@@ -108,12 +107,11 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 		fmtErr := fmt.Sprintf(scopeFailFmt, machine.Name, err)
 		return a.handleMachineError(machine, apierrors.UpdateMachine(fmtErr), updateEventAction)
 	}
-	defer scope.Close()
 	if err := newReconciler(scope).update(); err != nil {
 		return a.handleMachineError(machine, apierrors.UpdateMachine(err.Error()), updateEventAction)
 	}
 	a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, updateEventAction, "Updated Machine %v", machine.Name)
-	return nil
+	return scope.Close()
 }
 
 func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) error {

--- a/pkg/cloud/gcp/actuators/machine/machine_scope.go
+++ b/pkg/cloud/gcp/actuators/machine/machine_scope.go
@@ -91,22 +91,21 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 }
 
 // Close the MachineScope by persisting the machine spec, machine status after reconciling.
-func (s *machineScope) Close() {
+func (s *machineScope) Close() error {
 	if s.machineClient == nil {
-		klog.Errorf("No machineClient is set for this scope")
-		return
+		return errors.New("No machineClient is set for this scope")
 	}
 
 	latestMachine, err := s.storeMachineSpec(s.machine)
 	if err != nil {
-		klog.Errorf("[machinescope] failed to update machine %q in namespace %q: %v", s.machine.Name, s.machine.Namespace, err)
-		return
+		return fmt.Errorf("[machinescope] failed to update machine %q in namespace %q: %v", s.machine.Name, s.machine.Namespace, err)
 	}
 
-	_, err = s.storeMachineStatus(latestMachine)
-	if err != nil {
-		klog.Errorf("[machinescope] failed to store provider status for machine %q in namespace %q: %v", s.machine.Name, s.machine.Namespace, err)
+	if _, err = s.storeMachineStatus(latestMachine); err != nil {
+		return fmt.Errorf("[machinescope] failed to store provider status for machine %q in namespace %q: %v", s.machine.Name, s.machine.Namespace, err)
 	}
+
+	return nil
 }
 
 func (s *machineScope) storeMachineSpec(machine *machinev1.Machine) (*machinev1.Machine, error) {


### PR DESCRIPTION
This changes the signature of Close() to return an error. The callers
of this function were happening in a defer block - those blocks have
been removed and we now return any error to the caller.