### PR TITLE
Add project ID to machine provider spec

### DIFF
--- a/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -33,6 +33,7 @@ type GCPMachineProviderSpec struct {
 	MachineType        string                 `json:"machineType"`
 	Region             string                 `json:"region"`
 	Zone               string                 `json:"zone"`
+	ProjectID          string                 `json:"projectID,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/gcp/actuators/machine/machine_scope.go
+++ b/pkg/cloud/gcp/actuators/machine/machine_scope.go
@@ -63,9 +63,12 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 		return nil, fmt.Errorf("failed to get serviceAccountJSON: %v", err)
 	}
 
-	projectID, err := getProjectIDFromJSONKey([]byte(serviceAccountJSON))
-	if err != nil {
-		return nil, fmt.Errorf("error getting project from JSON key: %v", err)
+	projectID := providerSpec.ProjectID
+	if len(projectID) == 0 {
+		projectID, err = getProjectIDFromJSONKey([]byte(serviceAccountJSON))
+		if err != nil {
+			return nil, fmt.Errorf("error getting project from JSON key: %v", err)
+		}
 	}
 
 	oauthClient, err := createOauth2Client(serviceAccountJSON, compute.CloudPlatformScope)


### PR DESCRIPTION
The project associated with a particular GCP credential key may not be the same project that was specified for the cluster install. The service account associated with the credential key may exist in one project and manage a cluster in a different project. Adding a project ID to the machine provider spec ensures that the machine controller uses the intended project in the edge case where it's different than the project associated with the credential key.

If projectID is not specified on machine, use the one from the credential secret.