### PR TITLE
bug 1740004: Set additional machine annotations/labels to get pretty machine output

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	machinev1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	clustererror "github.com/openshift/cluster-api/pkg/controller/error"
+	machinecontroller "github.com/openshift/cluster-api/pkg/controller/machine"
 	"google.golang.org/api/compute/v1"
 	googleapi "google.golang.org/api/googleapi"
 	apicorev1 "k8s.io/api/core/v1"
@@ -193,6 +194,8 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 		}
 		r.providerStatus.Conditions = reconcileProviderConditions(r.providerStatus.Conditions, succeedCondition)
 
+		r.setMachineCloudProviderSpecifics(freshInstance)
+
 		if freshInstance.Status != "RUNNING" {
 			klog.Infof("%s: machine status is %q, requeuing...", r.machine.Name, freshInstance.Status)
 			return &clustererror.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
@@ -200,6 +203,23 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 	}
 
 	return nil
+}
+
+func (r *Reconciler) setMachineCloudProviderSpecifics(instance *compute.Instance) {
+	if r.machine.Labels == nil {
+		r.machine.Labels = make(map[string]string)
+	}
+
+	if r.machine.Annotations == nil {
+		r.machine.Annotations = make(map[string]string)
+	}
+
+	r.machine.Annotations[machinecontroller.MachineInstanceStateAnnotationName] = instance.Status
+	// TODO(jchaloup): detect all three from instance rather than
+	// always assuming it's the same as what is specified in the provider spec
+	r.machine.Labels[machinecontroller.MachineInstanceTypeLabelName] = r.providerSpec.MachineType
+	r.machine.Labels[machinecontroller.MachineRegionLabelName] = r.providerSpec.Region
+	r.machine.Labels[machinecontroller.MachineAZLabelName] = r.providerSpec.Zone
 }
 
 func (r *Reconciler) getCustomUserData() (string, error) {


### PR DESCRIPTION
Set common machine fields so when a machine provisioned in Azure is listed through oc get machines
all additional printer colums are properly populated. E.g. region, zone, instance type.

```
NAME                     STATE     TYPE            REGION  	 ZONE            AGE
jchalo-pm2hk-m-0         RUNNING   n1-standard-4   us-central1   us-central1-a   20h
jchalo-pm2hk-m-1         RUNNING   n1-standard-4   us-central1   us-central1-b   20h
jchalo-pm2hk-m-2         RUNNING   n1-standard-4   us-central1   us-central1-c   20h
jchalo-pm2hk-w-a-wfrmf   RUNNING   n1-standard-4   us-central1   us-central1-a   20h
jchalo-pm2hk-w-b-l2wv5   RUNNING   n1-standard-4   us-central1   us-central1-b   20h
jchalo-pm2hk-w-c-fvh4h   RUNNING   n1-standard-4   us-central1   us-central1-c   20h
```