### PR TITLE
Extend makefile with 'make goimports' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ endif
 fmt: ## Go fmt your code
 	hack/go-fmt.sh .
 
+.PHONY: goimports
+goimports: ## Go fmt your code
+	hack/goimports.sh .
+
 .PHONY: vet
 vet: ## Apply go vet to all go files
 	hack/go-vet.sh ./...

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+REPO_NAME=$(basename "${PWD}")
+if [ "$IS_CONTAINER" != "" ]; then
+  for TARGET in "${@}"; do
+    find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+
+  done
+  git diff --exit-code
+else
+  docker run -it --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
+    openshift/origin-release:golang-1.12 \
+    ./hack/goimports.sh "${@}"
+fi


### PR DESCRIPTION
So the target can be run in CI and fail in case files are not properly goimport formated.