### PR TITLE
Label instances created by the actuator with cluster ID

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -54,6 +54,11 @@ func (r *Reconciler) create() error {
 		},
 	}
 
+	if instance.Labels == nil {
+		instance.Labels = map[string]string{}
+	}
+	instance.Labels[fmt.Sprintf("kubernetes-io-cluster-%v", r.machine.Labels[machinev1.MachineClusterIDLabel])] = "owned"
+
 	// disks
 	var disks = []*compute.AttachedDisk{}
 	for _, disk := range r.providerSpec.Disks {
@@ -249,6 +254,11 @@ func validateMachine(machine machinev1.Machine, providerSpec v1beta1.GCPMachineP
 			}
 		}
 	}
+
+	if machine.Labels[machinev1.MachineClusterIDLabel] == "" {
+		return fmt.Errorf("machine is missing %q label", machinev1.MachineClusterIDLabel)
+	}
+
 	return nil
 }
 

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -20,6 +20,9 @@ func TestCreate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
 				Namespace: "",
+				Labels: map[string]string{
+					machinev1beta1.MachineClusterIDLabel: "CLUSTERID",
+				},
 			},
 		},
 		coreClient:     controllerfake.NewFakeClient(),
@@ -108,6 +111,9 @@ func TestExists(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
 				Namespace: "",
+				Labels: map[string]string{
+					machinev1beta1.MachineClusterIDLabel: "CLUSTERID",
+				},
 			},
 		},
 		coreClient:     controllerfake.NewFakeClient(),
@@ -129,6 +135,9 @@ func TestDelete(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
 				Namespace: "",
+				Labels: map[string]string{
+					machinev1beta1.MachineClusterIDLabel: "CLUSTERID",
+				},
 			},
 		},
 		coreClient:     controllerfake.NewFakeClient(),


### PR DESCRIPTION
So the installer can potentially delete all gcp instances when a cluster is destroyed.

Label key constraints: The key must start with a lowercase character,
can only contain lowercase letters, numeric characters, underscores and dashes.
The key can be at most 63 characters long. International characters are allowed.

Thus, using "kubernetes-io-cluster-CLUSTERID=owned" form instead.

```
$ gcloud compute instances list --format='table(name,status,labels.list())' | grep jchalo-cf757
jchalo-cf757-m-0                        RUNNING
jchalo-cf757-w-a-jwddf                  RUNNING
jchalo-cf757-m-1                        RUNNING
jchalo-cf757-w-b-92xt6                  RUNNING  kubernetes-io-cluster-jchalo-cf757=owned
jchalo-cf757-w-b-wd8nm                  RUNNING
jchalo-cf757-m-2                        RUNNING
jchalo-cf757-w-c-54v9j                  RUNNING
```