### PR TITLE
Fix linking on other architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-api-provider-gcp
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
- && GOPROXY=off NO_DOCKER=1 make build
+ && make build GOPROXY=off NO_DOCKER=1 CGO_ENABLED=0
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-gcp/bin/manager /


### PR DESCRIPTION
This avoids actual static linking of -lpthread,-lc,etc. on some architectures.

This reopens https://github.com/openshift/cluster-api-provider-gcp/pull/38.