### PR TITLE
Added way to pass mock for machine scope, improving test coverage

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -59,6 +59,7 @@ func main() {
 		CoreClient:        mgr.GetClient(),
 		EventRecorder:     mgr.GetEventRecorderFor("gcpcontroller"),
 		ReconcilerBuilder: machine.NewReconciler,
+		ScopeBuilder:      machine.NewMachineScope,
 	})
 
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,9 +55,10 @@ func main() {
 
 	// Initialize machine actuator.
 	machineActuator := machine.NewActuator(machine.ActuatorParams{
-		MachineClient: cs,
-		CoreClient:    mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("gcpcontroller"),
+		MachineClient:     cs,
+		CoreClient:        mgr.GetClient(),
+		EventRecorder:     mgr.GetEventRecorderFor("gcpcontroller"),
+		ReconcilerBuilder: machine.NewReconciler,
 	})
 
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {

--- a/pkg/cloud/gcp/actuators/machine/machine_scope.go
+++ b/pkg/cloud/gcp/actuators/machine/machine_scope.go
@@ -35,8 +35,8 @@ type machineScopeParams struct {
 	machine       *machinev1.Machine
 }
 
-// machineScope defines a scope defined around a machine and its cluster.
-type machineScope struct {
+// MachineScope defines a scope defined around a machine and its cluster.
+type MachineScope struct {
 	machineClient  machineclient.MachineInterface
 	coreClient     controllerclient.Client
 	projectID      string
@@ -54,9 +54,9 @@ type machineScope struct {
 	origProviderStatus *v1beta1.GCPMachineProviderStatus
 }
 
-// newMachineScope creates a new MachineScope from the supplied parameters.
+// NewMachineScope creates a new MachineScope from the supplied parameters.
 // This is meant to be called for each machine actuator operation.
-func newMachineScope(params machineScopeParams) (*machineScope, error) {
+func NewMachineScope(params machineScopeParams) (*MachineScope, error) {
 	providerSpec, err := v1beta1.ProviderSpecFromRawExtension(params.machine.Spec.ProviderSpec.Value)
 	if err != nil {
 		return nil, machineapierros.InvalidMachineConfiguration("failed to get machine config: %v", err)
@@ -89,7 +89,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 	if err != nil {
 		return nil, machineapierros.InvalidMachineConfiguration("error creating compute service: %v", err)
 	}
-	return &machineScope{
+	return &MachineScope{
 		machineClient: params.machineClient.Machines(params.machine.Namespace),
 		coreClient:    params.coreClient,
 		projectID:     projectID,
@@ -110,7 +110,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 }
 
 // Close the MachineScope by persisting the machine spec, machine status after reconciling.
-func (s *machineScope) Close() error {
+func (s *MachineScope) Close() error {
 	if s.machineClient == nil {
 		return errors.New("No machineClient is set for this scope")
 	}
@@ -138,7 +138,7 @@ func (s *machineScope) Close() error {
 	return nil
 }
 
-func (s *machineScope) storeMachineSpec() error {
+func (s *MachineScope) storeMachineSpec() error {
 	ext, err := v1beta1.RawExtensionFromProviderSpec(s.providerSpec)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func (s *machineScope) storeMachineSpec() error {
 	return nil
 }
 
-func (s *machineScope) storeMachineStatus() error {
+func (s *MachineScope) storeMachineStatus() error {
 	if equality.Semantic.DeepEqual(s.providerStatus, s.origProviderStatus) && equality.Semantic.DeepEqual(s.machine.Status.Addresses, s.origMachine.Status.Addresses) {
 		klog.Infof("%s: status unchanged", s.machine.Name)
 		return nil

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -29,18 +29,18 @@ const (
 
 // Reconciler are list of services required by machine actuator, easy to create a fake
 type Reconciler struct {
-	*machineScope
+	*MachineScope
 }
 
 // NewReconciler populates all the services based on input scope
-func newReconciler(scope *machineScope) *Reconciler {
+func NewReconciler(scope *MachineScope) *Reconciler {
 	return &Reconciler{
 		scope,
 	}
 }
 
 // Create creates machine if and only if machine exists, handled by cluster-api
-func (r *Reconciler) create() error {
+func (r *Reconciler) Create() error {
 	if err := validateMachine(*r.machine, *r.providerSpec); err != nil {
 		return machinecontroller.InvalidMachineConfiguration("failed validating machine provider spec: %v", err)
 	}
@@ -153,7 +153,8 @@ func (r *Reconciler) create() error {
 	return r.reconcileMachineWithCloudState(nil)
 }
 
-func (r *Reconciler) update() error {
+// Update updates existing machine only when it doesn't match desired state
+func (r *Reconciler) Update() error {
 	// Add target pools, if necessary
 	if err := r.processTargetPools(true, r.addInstanceToTargetPool); err != nil {
 		return err
@@ -276,8 +277,8 @@ func validateMachine(machine machinev1.Machine, providerSpec v1beta1.GCPMachineP
 	return nil
 }
 
-// Returns true if machine exists.
-func (r *Reconciler) exists() (bool, error) {
+// Exists Returns true if machine Exists.
+func (r *Reconciler) Exists() (bool, error) {
 	if err := validateMachine(*r.machine, *r.providerSpec); err != nil {
 		return false, fmt.Errorf("failed validating machine provider spec: %v", err)
 	}
@@ -305,13 +306,13 @@ func (r *Reconciler) exists() (bool, error) {
 	return false, fmt.Errorf("error getting running instances: %v", err)
 }
 
-// Returns true if machine exists.
-func (r *Reconciler) delete() error {
+// Delete deletes the machine
+func (r *Reconciler) Delete() error {
 	// Remove instance from target pools, if necessary
 	if err := r.processTargetPools(false, r.deleteInstanceFromTargetPool); err != nil {
 		return err
 	}
-	exists, err := r.exists()
+	exists, err := r.Exists()
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -113,7 +113,7 @@ func TestCreate(t *testing.T) {
 				labels = tc.labels
 			}
 
-			machineScope := machineScope{
+			machineScope := MachineScope{
 				machine: &machinev1beta1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "",
@@ -127,7 +127,7 @@ func TestCreate(t *testing.T) {
 				computeService: mockComputeService,
 			}
 
-			reconciler := newReconciler(&machineScope)
+			reconciler := NewReconciler(&machineScope)
 
 			if tc.secret != nil {
 				reconciler.coreClient = controllerfake.NewFakeClientWithScheme(scheme.Scheme, tc.secret)
@@ -137,7 +137,7 @@ func TestCreate(t *testing.T) {
 				mockComputeService.MockInstancesInsert = tc.mockInstancesInsert
 			}
 
-			err := reconciler.create()
+			err := reconciler.Create()
 
 			if tc.expectedCondition != nil {
 				if reconciler.providerStatus.Conditions[0].Type != tc.expectedCondition.Type {
@@ -176,7 +176,7 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 	zone := "us-east1-b"
 	projecID := "testProject"
 	instanceName := "testInstance"
-	machineScope := machineScope{
+	machineScope := MachineScope{
 		machine: &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      instanceName,
@@ -204,7 +204,7 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 		},
 	}
 
-	r := newReconciler(&machineScope)
+	r := NewReconciler(&machineScope)
 	if err := r.reconcileMachineWithCloudState(nil); err != nil {
 		t.Errorf("reconciler was not expected to return error: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
-	machineScope := machineScope{
+	machineScope := MachineScope{
 		machine: &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
@@ -243,8 +243,8 @@ func TestExists(t *testing.T) {
 		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 		computeService: mockComputeService,
 	}
-	reconciler := newReconciler(&machineScope)
-	exists, err := reconciler.exists()
+	reconciler := NewReconciler(&machineScope)
+	exists, err := reconciler.Exists()
 	if err != nil || exists != true {
 		t.Errorf("reconciler was not expected to return error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestExists(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
-	machineScope := machineScope{
+	machineScope := MachineScope{
 		machine: &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
@@ -267,8 +267,8 @@ func TestDelete(t *testing.T) {
 		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 		computeService: mockComputeService,
 	}
-	reconciler := newReconciler(&machineScope)
-	if err := reconciler.delete(); err != nil {
+	reconciler := NewReconciler(&machineScope)
+	if err := reconciler.Delete(); err != nil {
 		if _, ok := err.(*machinecontroller.RequeueAfterError); !ok {
 			t.Errorf("reconciler was not expected to return error: %v", err)
 		}
@@ -306,7 +306,7 @@ func TestProcessTargetPools(t *testing.T) {
 		"pool1",
 	}
 	tpEmpty := []string{}
-	machineScope := machineScope{
+	machineScope := MachineScope{
 		machine: &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      instanceName,
@@ -374,7 +374,7 @@ func TestProcessTargetPools(t *testing.T) {
 		pt := newPoolTracker()
 		machineScope.providerSpec.Region = tc.region
 		machineScope.providerSpec.TargetPools = tc.targetPools
-		rec := newReconciler(&machineScope)
+		rec := NewReconciler(&machineScope)
 		err := rec.processTargetPools(tc.desired, pt.track)
 		if err != nil {
 			t.Errorf("unexpected error from ptp")
@@ -389,7 +389,7 @@ func TestGetUserData(t *testing.T) {
 	userDataSecretName := "test"
 	defaultNamespace := "test"
 	userDataBlob := "test"
-	machineScope := machineScope{
+	machineScope := MachineScope{
 		machine: &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "",
@@ -403,7 +403,7 @@ func TestGetUserData(t *testing.T) {
 		},
 		providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 	}
-	reconciler := newReconciler(&machineScope)
+	reconciler := NewReconciler(&machineScope)
 
 	testCases := []struct {
 		secret *apiv1.Secret

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -21,53 +21,53 @@ type GCPComputeService interface {
 	TargetPoolsRemoveInstance(project string, region string, name string, instance string) (*compute.Operation, error)
 }
 
-type computeService struct {
+type ComputeService struct {
 	service *compute.Service
 }
 
 // NewComputeService return a new computeService
-func NewComputeService(oauthClient *http.Client) (*computeService, error) {
+func NewComputeService(oauthClient *http.Client) (GCPComputeService, error) {
 	service, err := compute.New(oauthClient)
 	if err != nil {
 		return nil, err
 	}
 	service.UserAgent = "gcpprovider.openshift.io/" + version.Version.String()
-	return &computeService{
+	return &ComputeService{
 		service: service,
 	}, nil
 }
 
 // InstancesInsert is a pass through wrapper for compute.Service.Instances.Insert(...)
-func (c *computeService) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+func (c *ComputeService) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
 	return c.service.Instances.Insert(project, zone, instance).Do()
 }
 
 // ZoneOperationsGet is a pass through wrapper for compute.Service.ZoneOperations.Get(...)
-func (c *computeService) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
+func (c *ComputeService) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
 	return c.service.ZoneOperations.Get(project, zone, operation).Do()
 }
 
-func (c *computeService) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
+func (c *ComputeService) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
 	return c.service.Instances.Get(project, zone, instance).Do()
 }
 
-func (c *computeService) InstancesDelete(requestId string, project string, zone string, instance string) (*compute.Operation, error) {
+func (c *ComputeService) InstancesDelete(requestId string, project string, zone string, instance string) (*compute.Operation, error) {
 	return c.service.Instances.Delete(project, zone, instance).RequestId(requestId).Do()
 }
 
-func (c *computeService) ZonesGet(project string, zone string) (*compute.Zone, error) {
+func (c *ComputeService) ZonesGet(project string, zone string) (*compute.Zone, error) {
 	return c.service.Zones.Get(project, zone).Do()
 }
 
-func (c *computeService) BasePath() string {
+func (c *ComputeService) BasePath() string {
 	return c.service.BasePath
 }
 
-func (c *computeService) TargetPoolsGet(project string, region string, name string) (*compute.TargetPool, error) {
+func (c *ComputeService) TargetPoolsGet(project string, region string, name string) (*compute.TargetPool, error) {
 	return c.service.TargetPools.Get(project, region, name).Do()
 }
 
-func (c *computeService) TargetPoolsAddInstance(project string, region string, name string, instanceLink string) (*compute.Operation, error) {
+func (c *ComputeService) TargetPoolsAddInstance(project string, region string, name string, instanceLink string) (*compute.Operation, error) {
 	rb := &compute.TargetPoolsAddInstanceRequest{
 		Instances: []*compute.InstanceReference{
 			{
@@ -78,7 +78,7 @@ func (c *computeService) TargetPoolsAddInstance(project string, region string, n
 	return c.service.TargetPools.AddInstance(project, region, name, rb).Do()
 }
 
-func (c *computeService) TargetPoolsRemoveInstance(project string, region string, name string, instanceLink string) (*compute.Operation, error) {
+func (c *ComputeService) TargetPoolsRemoveInstance(project string, region string, name string, instanceLink string) (*compute.Operation, error) {
 	rb := &compute.TargetPoolsRemoveInstanceRequest{
 		Instances: []*compute.InstanceReference{
 			{


### PR DESCRIPTION
- Allowing to mock gcp machine scope to test `actuator` code
- Allowing to pass a mock to a compute service

Blocked by #70, as there is no reason to mock `machineClient` due to it's absence in future versions, as well as in upstream.