### PR TITLE
Restore original make unit behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,8 @@ test: ## Run tests
 	@echo -e "\033[32mTesting...\033[0m"
 	$(DOCKER_CMD) hack/ci-test.sh
 
-## TODO(JoelSpeed): Make CI depend on `test` target and rename `unit-internal` to `unit` to restore original behaviour
 .PHONY: unit
-unit: test
-
-.PHONY: unit-internal
-unit-internal: # Run unit test
+unit: # Run unit test
 	$(DOCKER_CMD) go test -race -cover ./cmd/... ./pkg/...
 
 .PHONY: sec

--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -24,4 +24,4 @@ cd $REPO_ROOT && \
 	source ./hack/fetch-ext-bins.sh && \
 	fetch_tools && \
 	setup_envs && \
-	make unit-internal
+	make unit


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR restores the original behaviour of `make unit`, depends on https://github.com/openshift/release/pull/7755 being merged first