### PR TITLE
[OCPCLOUD-492] Implement leader election for gcp provider

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-api-provider-gcp/pkg/apis"
@@ -22,24 +23,47 @@ import (
 )
 
 func main() {
-	var printVersion bool
-	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+	printVersion := flag.Bool(
+		"version",
+		false,
+		"print version and exit",
+	)
 
-	klog.InitFlags(nil)
+	leaderElectResourceNamespace := flag.String(
+		"leader-elect-resource-namespace",
+		"",
+		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
+	)
+
+	leaderElect := flag.Bool(
+		"leader-elect",
+		false,
+		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+	)
+
+	leaderElectLeaseDuration := flag.Duration(
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+	)
+
 	watchNamespace := flag.String(
 		"namespace",
 		"",
 		"Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.",
 	)
+
 	healthAddr := flag.String(
 		"health-addr",
 		":9440",
 		"The address for health checking.",
 	)
+
+	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	if printVersion {
+	if *printVersion {
 		fmt.Println(version.String)
 		os.Exit(0)
 	}
@@ -47,10 +71,15 @@ func main() {
 	cfg := config.GetConfigOrDie()
 
 	opts := manager.Options{
+		LeaderElection:          *leaderElect,
+		LeaderElectionNamespace: *leaderElectResourceNamespace,
+		LeaderElectionID:        "cluster-api-provider-gcp-leader",
+		LeaseDuration:           leaderElectLeaseDuration,
 		// Disable metrics serving
 		MetricsBindAddress:     "0",
 		HealthProbeBindAddress: *healthAddr,
 	}
+
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
 		klog.Infof("Watching machine-api objects only in namespace %q for reconciliation.", opts.Namespace)


### PR DESCRIPTION
Couple of new cli arguments for configuring leader election:

```
  -leader-elect
    	Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default true)
  -leader-elect-lease-duration int
    	The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 15s)
  -leader-elect-resource-namespace string
    	The namespace of resource object that is used for locking during leader election. If unspecified, the controller watches for machine-api objects across all namespaces.

```