### PR TITLE
Bug 1828288: Deprecated machine.openshift.io/memoryMb annotation in favour of machine.openshift.io/memory

### DIFF
--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -39,7 +39,7 @@ const (
 	// This is needed by the autoscaler to foresee upcoming capacity when scaling from zero.
 	// https://github.com/openshift/enhancements/pull/186
 	cpuKey    = "machine.openshift.io/vCPU"
-	memoryKey = "machine.openshift.io/memoryMb"
+	memoryKey = "machine.openshift.io/memory"
 )
 
 // Reconciler reconciles machineSets.
@@ -152,7 +152,8 @@ func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, e
 
 	// TODO: get annotations keys from machine API
 	machineSet.Annotations[cpuKey] = strconv.FormatInt(machineType.GuestCpus, 10)
-	machineSet.Annotations[memoryKey] = strconv.FormatInt(machineType.MemoryMb, 10)
+	// See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+	machineSet.Annotations[memoryKey] = fmt.Sprintf("%sM", strconv.FormatInt(machineType.MemoryMb, 10))
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/cloud/gcp/actuators/machineset/controller_test.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Reconciler", func() {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "2",
-				memoryKey: "7680",
+				memoryKey: "7680M",
 			},
 			expectedEvents: []string{},
 		}),
@@ -152,7 +152,7 @@ var _ = Describe("Reconciler", func() {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "16",
-				memoryKey: "16384",
+				memoryKey: "16384M",
 			},
 			expectedEvents: []string{},
 		}),
@@ -166,7 +166,7 @@ var _ = Describe("Reconciler", func() {
 				"existing": "annotation",
 				"annother": "existingAnnotation",
 				cpuKey:     "2",
-				memoryKey:  "7680",
+				memoryKey:  "7680M",
 			},
 			expectedEvents: []string{},
 		}),
@@ -240,7 +240,7 @@ func TestReconcile(t *testing.T) {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "2",
-				memoryKey: "7680",
+				memoryKey: "7680M",
 			},
 			expectErr: false,
 		},
@@ -251,7 +251,7 @@ func TestReconcile(t *testing.T) {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "16",
-				memoryKey: "16384",
+				memoryKey: "16384M",
 			},
 			expectErr: false,
 		},
@@ -267,7 +267,7 @@ func TestReconcile(t *testing.T) {
 				"existing": "annotation",
 				"annother": "existingAnnotation",
 				cpuKey:     "2",
-				memoryKey:  "7680",
+				memoryKey:  "7680M",
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
Cluster autoscaler and aws/gcp/azure controllers should drop the "machine.openshift.io/memoryMb" deprecated annotation and use only "machine.openshift.io/memory".

This way controllers are responsible to set the unit format according to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory while the autoscaler should be able to read it appropiately.
This is more robust and practical than the current approach and assumptions.
https://bugzilla.redhat.com/show_bug.cgi?id=1828288

Needs https://github.com/openshift/kubernetes-autoscaler/pull/145
/hold