### PR TITLE
apis: support specifying custom hostname for the machines

### DIFF
--- a/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -35,6 +35,13 @@ type GCPMachineProviderSpec struct {
 	Region             string                 `json:"region"`
 	Zone               string                 `json:"zone"`
 	ProjectID          string                 `json:"projectID,omitempty"`
+
+	// hostname is used to specify the custom hostname for the machine.
+	// Must be a fully qualified DNS name and RFC-1035-valid. Valid format is a series of labels 1-63 characters long
+	// matching the regular expression [a-z]([-a-z0-9]*[a-z0-9]), concatenated with periods.
+	// The entire hostname must not exceed 253 characters
+	// +optional
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
GCP allows users to set custom hostname, this esp useful for OS like RHCOS that have limit on the length of the hostname

by default the GCP send DHCP information with the default hostnames as doc in https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names
But these names are quite longer than 64 characters and this cause the RHCOS to fail to add the hostname. Allowing custom hostnames should help setting shorter hostnames.