### PR TITLE
Bug 1809345: Add the machine's name as a known NodeInternalDNS

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -197,6 +197,13 @@ func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *v1beta1.GCP
 			Type:    corev1.NodeInternalDNS,
 			Address: fmt.Sprintf("%s.c.%s.internal", r.machine.Name, r.projectID),
 		})
+		// Add the machine's name as a known NodeInternalDNS because GCP platform
+		// provides search paths to resolve those.
+		// https://cloud.google.com/compute/docs/internal-dns#resolv.conf
+		nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
+			Type:    corev1.NodeInternalDNS,
+			Address: r.machine.GetName(),
+		})
 
 		r.machine.Spec.ProviderID = &r.providerID
 		r.machine.Status.Addresses = nodeAddresses


### PR DESCRIPTION
GCP platform provides search paths to resolve the virtual machine names by default. see https://cloud.google.com/compute/docs/internal-dns#resolv.conf

this also allows nodes in clusters to have node-names matching the virtual machine name instead of the fqdn be because fqdn is too long for RHCOS to accept as hostname
by default