### PR TITLE
Add termination handler for spot instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN unset VERSION \
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-gcp/bin/machine-controller-manager /
+COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-gcp/bin/termination-handler /

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ sec: # Run security static analysis
 build: ## build binaries
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/machine-controller-manager" \
                -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/manager"
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/termination-handler" \
+               -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/termination-handler"
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/cmd/termination-handler/main.go
+++ b/cmd/termination-handler/main.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/openshift/cluster-api-provider-gcp/pkg/termination"
+	"github.com/openshift/cluster-api-provider-gcp/pkg/version"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func main() {
+	var printVersion bool
+	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+
+	klog.InitFlags(nil)
+	logger := klogr.New()
+
+	pollIntervalSeconds := flag.Int64("poll-interval-seconds", 5, "interval in seconds at which termination notice endpoint should be checked (Default: 5)")
+	nodeName := flag.String("node-name", "", "name of the node that the termination handler is running on")
+	namespace := flag.String("namespace", "", "namespace that the machine for the node should live in. If unspecified, look for machines across all namespaces.")
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	if printVersion {
+		fmt.Println(version.String)
+		os.Exit(0)
+	}
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		logger.Error(err, "Error getting configuration")
+		return
+	}
+
+	// Get the poll interval as a duration from the `poll-interval-seconds` flag
+	pollInterval := time.Duration(*pollIntervalSeconds) * time.Second
+
+	// Construct a termination handler
+	handler, err := termination.NewHandler(logger, cfg, pollInterval, *namespace, *nodeName)
+	if err != nil {
+		logger.Error(err, "Error constructing termination handler")
+		return
+	}
+
+	// Start the termination handler
+	if err := handler.Run(ctrl.SetupSignalHandler()); err != nil {
+		logger.Error(err, "Error starting termination handler")
+		return
+	}
+}

--- a/config/crds/machine.openshift.io.crd.yaml
+++ b/config/crds/machine.openshift.io.crd.yaml
@@ -1,0 +1,120 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: machines.machine.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.providerStatus.instanceId
+    name: Instance
+    description: Instance ID of machine created in AWS
+    type: string
+  - JSONPath: .status.providerStatus.instanceState
+    name: State
+    description: State of the AWS instance
+    type: string
+  - JSONPath: .spec.providerSpec.value.instanceType
+    name: Type
+    description: Type of instance
+    type: string
+  - JSONPath: .spec.providerSpec.value.placement.region
+    name: Region
+    description: Region associated with machine
+    type: string
+  - JSONPath: .spec.providerSpec.value.placement.availabilityZone
+    name: Zone
+    description: Zone associated with machine
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: machine.openshift.io
+  names:
+    kind: Machine
+    plural: machines
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          properties:
+            configSource:
+              type: object
+            metadata:
+              type: object
+            providerSpec:
+              properties:
+                value:
+                  type: object
+                valueFrom:
+                  properties:
+                    machineClass:
+                      properties:
+                        provider:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            taints:
+              items:
+                type: object
+              type: array
+            versions:
+              properties:
+                controlPlane:
+                  type: string
+                kubelet:
+                  type: string
+              required:
+              - kubelet
+              type: object
+          required:
+          - providerSpec
+        status:
+          properties:
+            addresses:
+              items:
+                type: object
+              type: array
+            conditions:
+              items:
+                type: object
+              type: array
+            errorMessage:
+              type: string
+            errorReason:
+              type: string
+            lastUpdated:
+              format: date-time
+              type: string
+            nodeRef:
+              type: object
+            providerStatus:
+              type: object
+            versions:
+              properties:
+                controlPlane:
+                  type: string
+                kubelet:
+                  type: string
+              required:
+              - kubelet
+              type: object
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -246,6 +246,10 @@ func (r *Reconciler) setMachineCloudProviderSpecifics(instance *compute.Instance
 	r.machine.Labels[machinecontroller.MachineInstanceTypeLabelName] = r.providerSpec.MachineType
 	r.machine.Labels[machinecontroller.MachineRegionLabelName] = r.providerSpec.Region
 	r.machine.Labels[machinecontroller.MachineAZLabelName] = r.providerSpec.Zone
+
+	if r.providerSpec.Preemptible {
+		r.machine.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
+	}
 }
 
 func (r *Reconciler) getCustomUserData() (string, error) {

--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -1,0 +1,155 @@
+package termination
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	gcpTerminationEndpointURL = "http://169.254.169.254/computeMetadata/v1/instance/preempted"
+)
+
+// Handler represents a handler that will run to check the termination
+// notice endpoint and delete Machine's if the instance termination notice is fulfilled.
+type Handler interface {
+	Run(stop <-chan struct{}) error
+}
+
+// NewHandler constructs a new Handler
+func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, namespace, nodeName string) (Handler, error) {
+	c, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %v", err)
+	}
+
+	pollURL, err := url.Parse(gcpTerminationEndpointURL)
+	if err != nil {
+		// This should never happen
+		panic(err)
+	}
+
+	logger = logger.WithValues("node", nodeName, "namespace", namespace)
+
+	return &handler{
+		client:       c,
+		pollURL:      pollURL,
+		pollInterval: pollInterval,
+		nodeName:     nodeName,
+		namespace:    namespace,
+		log:          logger,
+	}, nil
+}
+
+// handler implements the logic to check the termination endpoint and delete the
+// machine associated with the node
+type handler struct {
+	client       client.Client
+	pollURL      *url.URL
+	pollInterval time.Duration
+	nodeName     string
+	namespace    string
+	log          logr.Logger
+}
+
+// Run starts the handler and runs the termination logic
+func (h *handler) Run(stop <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errs := make(chan error, 1)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		errs <- h.run(ctx)
+	}()
+
+	select {
+	case <-stop:
+		cancel()
+		// Wait for run to stop
+		wg.Wait()
+		return nil
+	case err := <-errs:
+		cancel()
+		return err
+	}
+}
+
+func (h *handler) run(ctx context.Context) error {
+	machine, err := h.getMachineForNode(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching machine for node (%q): %w", h.nodeName, err)
+	}
+
+	logger := h.log.WithValues("machine", machine.Name)
+	logger.V(1).Info("Monitoring node for machine")
+
+	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
+		req, err := http.NewRequest("GET", h.pollURL.String(), nil)
+		if err != nil {
+			return false, fmt.Errorf("could not create request %q: %w", h.pollURL.String(), err)
+		}
+
+		req.Header.Add("Metadata-Flavor", "Google")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("could not get URL %q: %w", h.pollURL.String(), err)
+		}
+
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read responce body: %w", err)
+		}
+
+		respBody := string(bodyBytes)
+
+		if respBody == "TRUE" {
+			// Instance marked for termination
+			return true, nil
+		}
+
+		// Instance not terminated yet
+		logger.V(2).Info("Instance not marked for termination")
+		return false, nil
+	}, ctx.Done()); err != nil {
+		return fmt.Errorf("error polling termination endpoint: %w", err)
+	}
+
+	// Will only get here if the termination endpoint returned FALSE
+	logger.V(1).Info("Instance marked for termination, deleting Machine")
+	if err := h.client.Delete(ctx, machine); err != nil {
+		return fmt.Errorf("error deleting machine: %w", err)
+	}
+
+	return nil
+}
+
+// getMachineForNodeName finds the Machine associated with the Node name given
+func (h *handler) getMachineForNode(ctx context.Context) (*machinev1.Machine, error) {
+	machineList := &machinev1.MachineList{}
+	err := h.client.List(ctx, machineList, client.InNamespace(h.namespace))
+	if err != nil {
+		return nil, fmt.Errorf("error listing machines: %w", err)
+	}
+
+	for _, machine := range machineList.Items {
+		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == h.nodeName {
+			return &machine, nil
+		}
+	}
+
+	return nil, fmt.Errorf("machine not found for node %q", h.nodeName)
+}

--- a/pkg/termination/termination_suite_test.go
+++ b/pkg/termination/termination_suite_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+const (
+	timeout       = 10 * time.Second
+	testNamespace = "test-namespace"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+
+	ctx = context.Background()
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Termination Handler Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crds")},
+	}
+	machinev1.AddToScheme(scheme.Scheme)
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{})
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNamespace,
+		},
+	})).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// StartTestHandler starts the test handler
+func StartTestHandler(th Handler) (chan struct{}, chan error) {
+	stop := make(chan struct{})
+	errs := make(chan error)
+	go func() {
+		errs <- th.Run(stop)
+	}()
+	return stop, errs
+}

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var notPreempted = func(rw http.ResponseWriter, req *http.Request) {
+	rw.Write([]byte("FALSE"))
+}
+
+var _ = Describe("Handler Suite", func() {
+	var terminationServer *httptest.Server
+	var httpHandler http.Handler
+	var nodeName string
+	var stop chan struct{}
+	var errs chan error
+	var h *handler
+
+	BeforeEach(func() {
+		// Reset test vars
+		terminationServer = nil
+		httpHandler = nil
+		nodeName = "test-node"
+		httpHandler = newMockHTTPHandler(notPreempted)
+
+		h = &handler{
+			client:       k8sClient,
+			pollInterval: 100 * time.Millisecond,
+			nodeName:     nodeName,
+			log:          klogr.New(),
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(httpHandler).ToNot(BeNil())
+		terminationServer = httptest.NewServer(httpHandler)
+
+		if h.pollURL == nil {
+			pollURL, err := url.Parse(terminationServer.URL)
+			Expect(err).ToNot(HaveOccurred())
+			h.pollURL = pollURL
+		}
+
+		stop, errs = StartTestHandler(h)
+	})
+
+	AfterEach(func() {
+		if !isClosed(stop) {
+			close(stop)
+		}
+		terminationServer.Close()
+
+		Expect(deleteAllMachines(k8sClient)).To(Succeed())
+	})
+
+	Context("when the handler is stopped", func() {
+		JustBeforeEach(func() {
+			close(stop)
+		})
+
+		It("should not return an error", func() {
+			Eventually(errs).Should(Receive(BeNil()))
+		})
+	})
+
+	Context("when no machine exists for the node", func() {
+		It("should return an error upon starting", func() {
+			Eventually(errs).Should(Receive(MatchError("error fetching machine for node (\"test-node\"): machine not found for node \"test-node\"")))
+		})
+	})
+
+	Context("when a machine exists for the node", func() {
+		var counter int32
+		var testMachine *machinev1.Machine
+
+		BeforeEach(func() {
+			testMachine = newTestMachine("test-machine", testNamespace, nodeName)
+			createMachine(testMachine)
+
+			// Ensure the polling logic is excercised in tests
+			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+				if atomic.LoadInt32(&counter) == 4 {
+					rw.Write([]byte("TRUE"))
+				} else {
+					atomic.AddInt32(&counter, 1)
+					rw.Write([]byte("FALSE"))
+				}
+			})
+		})
+
+		JustBeforeEach(func() {
+			// Ensure the polling logic is excercised in tests
+			for atomic.LoadInt32(&counter) < 4 {
+				continue
+			}
+		})
+
+		Context("and the handler is stopped", func() {
+			JustBeforeEach(func() {
+				close(stop)
+			})
+
+			It("should not return an error", func() {
+				Eventually(errs).Should(Receive(BeNil()))
+			})
+
+			It("should not delete the machine", func() {
+				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+				Consistently(func() error {
+					m := &machinev1.Machine{}
+					return k8sClient.Get(ctx, key, m)
+				}).Should(Succeed())
+			})
+		})
+
+		Context("and the instance termination notice is fulfilled", func() {
+			It("should delete the machine", func() {
+				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+				Eventually(func() error {
+					m := &machinev1.Machine{}
+					err := k8sClient.Get(ctx, key, m)
+					if err != nil && errors.IsNotFound(err) {
+						return nil
+					} else if err != nil {
+						return err
+					}
+					return fmt.Errorf("machine not yet deleted")
+				}).Should(Succeed())
+			})
+		})
+
+		Context("and the instance termination notice is not fulfilled", func() {
+			BeforeEach(func() {
+				httpHandler = newMockHTTPHandler(notPreempted)
+			})
+
+			It("should not delete the machine", func() {
+				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+				Consistently(func() error {
+					m := &machinev1.Machine{}
+					return k8sClient.Get(ctx, key, m)
+				}).Should(Succeed())
+			})
+		})
+
+		Context("and the poll URL cannot be reached", func() {
+			BeforeEach(func() {
+				h.pollURL = &url.URL{Opaque: "abc#1://localhost"}
+			})
+
+			It("should return an error", func() {
+				Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
+			})
+
+			It("should not delete the machine", func() {
+				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+				Consistently(func() error {
+					m := &machinev1.Machine{}
+					return k8sClient.Get(ctx, key, m)
+				}).Should(Succeed())
+			})
+		})
+	})
+
+	Context("getMachineForNode", func() {
+		var machine *machinev1.Machine
+		var err error
+
+		JustBeforeEach(func() {
+			machine, err = h.getMachineForNode(ctx)
+		})
+
+		Context("with a broken client", func() {
+			BeforeEach(func() {
+				brokenClient, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
+				Expect(err).ToNot(HaveOccurred())
+				h.client = brokenClient
+			})
+
+			It("should return an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("error listing machines: no kind is registered for the type v1beta1.MachineList in scheme"))
+			})
+
+			It("should not return a machine", func() {
+				Expect(machine).To(BeNil())
+			})
+		})
+
+		Context("with no machine for the node name", func() {
+			It("should return an error", func() {
+				Expect(err).To(MatchError("machine not found for node \"test-node\""))
+			})
+
+			It("should not return a machine", func() {
+				Expect(machine).To(BeNil())
+			})
+		})
+
+		Context("with a machine matching the node name", func() {
+			var testMachine *machinev1.Machine
+
+			BeforeEach(func() {
+				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
+				createMachine(testMachine)
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return a machine", func() {
+				Expect(machine).To(Equal(testMachine))
+			})
+		})
+	})
+})
+
+// mockHTTPHandler is used to mock the pollURL responses during tests
+type mockHTTPHandler struct {
+	handleFunc func(rw http.ResponseWriter, req *http.Request)
+}
+
+// ServeHTTP implements the http.Handler interface
+func (m *mockHTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	m.handleFunc(rw, req)
+}
+
+// newMockHTTPHandler constructs a mockHTTPHandler with the given handleFunc
+func newMockHTTPHandler(handleFunc func(http.ResponseWriter, *http.Request)) http.Handler {
+	return &mockHTTPHandler{handleFunc: handleFunc}
+}
+
+// isClosed checks if a channel is closed already
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
+}
+
+func deleteAllMachines(c client.Client) error {
+	machineList := &machinev1.MachineList{}
+	err := c.List(ctx, machineList)
+	if err != nil {
+		return fmt.Errorf("error listing machines: %v", err)
+	}
+
+	// Delete all machines found
+	for _, machine := range machineList.Items {
+		m := machine
+		err := c.Delete(ctx, &m)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newTestMachine(name, namespace, nodeName string) *machinev1.Machine {
+	return &machinev1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: machinev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: machinev1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: nodeName,
+			},
+		},
+	}
+}
+
+func createMachine(m *machinev1.Machine) {
+	typeMeta := m.TypeMeta
+	status := m.Status
+	Expect(k8sClient.Create(ctx, m)).To(Succeed())
+	m.Status = status
+	Expect(k8sClient.Status().Update(ctx, m)).To(Succeed())
+
+	// Fetch object to sync back to latest changes
+	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
+	Expect(k8sClient.Get(ctx, key, m)).To(Succeed())
+	// Restore TypeMeta as not restored by Get
+	m.TypeMeta = typeMeta
+}


### PR DESCRIPTION
This PR adds a termination handler for spot instances. It is based on the termination handler that Joel wrote for AWS and has similar logic.

Based on [documentation](https://cloud.google.com/compute/docs/instances/preemptible), spot instances run on GCP for 24 hours, but under some conditions, they might be terminated earlier so polling logic inherited from AWS should be the best option here.

This implementation of the termination handler is simpler than https://github.com/GoogleCloudPlatform/k8s-node-termination-handler, made specifically for machine API, and leverages its ability for draining nodes.

https://cloud.google.com/compute/docs/instances/preemptible

https://github.com/openshift/cluster-api-provider-aws/pull/308

https://cloud.google.com/compute/docs/instances/create-start-preemptible-instance#detecting_if_an_instance_was_preempted

https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/spot-instances.md