### PR TITLE
Add spot instance label to machine spec

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -248,7 +248,10 @@ func (r *Reconciler) setMachineCloudProviderSpecifics(instance *compute.Instance
 	r.machine.Labels[machinecontroller.MachineAZLabelName] = r.providerSpec.Zone
 
 	if r.providerSpec.Preemptible {
-		r.machine.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
+		if r.machine.Spec.Labels == nil {
+			r.machine.Spec.Labels = make(map[string]string)
+		}
+		r.machine.Spec.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
 	}
 }
 

--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -13,6 +13,7 @@ import (
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -28,6 +29,7 @@ type Handler interface {
 
 // NewHandler constructs a new Handler
 func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, namespace, nodeName string) (Handler, error) {
+	machinev1.AddToScheme(scheme.Scheme)
 	c, err := client.New(cfg, client.Options{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err)


### PR DESCRIPTION
Add spot instance label to machine spec, we need this label to be passed to the node.
