### PR TITLE
support sourceImage outside the existing project

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -69,6 +69,11 @@ func (r *Reconciler) create() error {
 	// disks
 	var disks = []*compute.AttachedDisk{}
 	for _, disk := range r.providerSpec.Disks {
+		srcImage := disk.Image
+		if strings.Index(disk.Image, "/") == -1 {
+			// only image name provided therfore defaulting to the current project
+			srcImage = googleapi.ResolveRelative(r.computeService.BasePath(), fmt.Sprintf("%s/global/images/%s", r.projectID, disk.Image))
+		}
 		disks = append(disks, &compute.AttachedDisk{
 			AutoDelete: disk.AutoDelete,
 			Boot:       disk.Boot,
@@ -76,7 +81,7 @@ func (r *Reconciler) create() error {
 				DiskSizeGb:  disk.SizeGb,
 				DiskType:    fmt.Sprintf("zones/%s/diskTypes/%s", zone, disk.Type),
 				Labels:      disk.Labels,
-				SourceImage: googleapi.ResolveRelative(r.computeService.BasePath(), fmt.Sprintf("%s/global/images/%s", r.projectID, disk.Image)),
+				SourceImage: srcImage,
 			},
 		})
 	}


### PR DESCRIPTION
Based on the api reference for [compute.instance.insert][0]

```
disks[].initializeParams.sourceImage:

The source image to create this disk. When creating a new instance, one of initializeParams.sourceImage or initializeParams.sourceSnapshot or disks.source is required except for local SSD.
To create a disk with one of the public operating system images, specify the image by its family name. For example, specify family/debian-9 to use the latest Debian 9 image:

projects/debian-cloud/global/images/family/debian-9

Alternatively, use a specific version of a public operating system image:

projects/debian-cloud/global/images/debian-9-stretch-vYYYYMMDD

To create a disk with a custom image that you created, specify the image name in the following format:

global/images/my-custom-image

You can also specify a custom image by its image family, which returns the latest version of the image in that family. Replace the image name with family/family-name:

global/images/family/my-image-family
```

Currently the provider always assumes that the image will be in the same project as the machine and it massages the input to match that.

To allow users to provide source image based on examples mentioned above, we pass it as-is unless we know that input is just image-name.

[0]: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert