### PR TITLE
BUG 1856597: Pass scheme to client creation so that it uses scheme with Machine API

### DIFF
--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,7 +30,7 @@ type Handler interface {
 // NewHandler constructs a new Handler
 func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, namespace, nodeName string) (Handler, error) {
 	machinev1.AddToScheme(scheme.Scheme)
-	c, err := client.New(cfg, client.Options{})
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err)
 	}

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Handler Suite", func() {
 		httpHandler = nil
 		nodeName = "test-node"
 		httpHandler = newMockHTTPHandler(notPreempted)
+		stop = nil
+		errs = nil
 
 		// use NewHandler() instead of manual construction in order to test NewHandler() logic
 		// like checking that machine api is added to scheme
@@ -71,12 +73,10 @@ var _ = Describe("Handler Suite", func() {
 			Expect(err).ToNot(HaveOccurred())
 			h.pollURL = pollURL
 		}
-
-		stop, errs = StartTestHandler(h)
 	})
 
 	AfterEach(func() {
-		if !isClosed(stop) {
+		if stop != nil && !isClosed(stop) {
 			close(stop)
 		}
 		terminationServer.Close()
@@ -84,49 +84,12 @@ var _ = Describe("Handler Suite", func() {
 		Expect(deleteAllMachines(k8sClient)).To(Succeed())
 	})
 
-	Context("when the handler is stopped", func() {
+	Context("when running the handler", func() {
 		JustBeforeEach(func() {
-			close(stop)
+			stop, errs = StartTestHandler(h)
 		})
 
-		It("should not return an error", func() {
-			Eventually(errs).Should(Receive(BeNil()))
-		})
-	})
-
-	Context("when no machine exists for the node", func() {
-		It("should return an error upon starting", func() {
-			Eventually(errs).Should(Receive(MatchError("error fetching machine for node (\"test-node\"): machine not found for node \"test-node\"")))
-		})
-	})
-
-	Context("when a machine exists for the node", func() {
-		var counter int32
-		var testMachine *machinev1.Machine
-
-		BeforeEach(func() {
-			testMachine = newTestMachine("test-machine", testNamespace, nodeName)
-			createMachine(testMachine)
-
-			// Ensure the polling logic is excercised in tests
-			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
-				if atomic.LoadInt32(&counter) == 4 {
-					rw.Write([]byte("TRUE"))
-				} else {
-					atomic.AddInt32(&counter, 1)
-					rw.Write([]byte("FALSE"))
-				}
-			})
-		})
-
-		JustBeforeEach(func() {
-			// Ensure the polling logic is excercised in tests
-			for atomic.LoadInt32(&counter) < 4 {
-				continue
-			}
-		})
-
-		Context("and the handler is stopped", func() {
+		Context("when the handler is stopped", func() {
 			JustBeforeEach(func() {
 				close(stop)
 			})
@@ -134,61 +97,104 @@ var _ = Describe("Handler Suite", func() {
 			It("should not return an error", func() {
 				Eventually(errs).Should(Receive(BeNil()))
 			})
+		})
 
-			It("should not delete the machine", func() {
-				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-				Consistently(func() error {
-					m := &machinev1.Machine{}
-					return k8sClient.Get(ctx, key, m)
-				}).Should(Succeed())
+		Context("when no machine exists for the node", func() {
+			It("should return an error upon starting", func() {
+				Eventually(errs).Should(Receive(MatchError("error fetching machine for node (\"test-node\"): machine not found for node \"test-node\"")))
 			})
 		})
 
-		Context("and the instance termination notice is fulfilled", func() {
-			It("should delete the machine", func() {
-				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-				Eventually(func() error {
-					m := &machinev1.Machine{}
-					err := k8sClient.Get(ctx, key, m)
-					if err != nil && errors.IsNotFound(err) {
-						return nil
-					} else if err != nil {
-						return err
+		Context("when a machine exists for the node", func() {
+			var counter int32
+			var testMachine *machinev1.Machine
+
+			BeforeEach(func() {
+				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
+				createMachine(testMachine)
+
+				// Ensure the polling logic is excercised in tests
+				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+					if atomic.LoadInt32(&counter) == 4 {
+						rw.Write([]byte("TRUE"))
+					} else {
+						atomic.AddInt32(&counter, 1)
+						rw.Write([]byte("FALSE"))
 					}
-					return fmt.Errorf("machine not yet deleted")
-				}).Should(Succeed())
-			})
-		})
-
-		Context("and the instance termination notice is not fulfilled", func() {
-			BeforeEach(func() {
-				httpHandler = newMockHTTPHandler(notPreempted)
+				})
 			})
 
-			It("should not delete the machine", func() {
-				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-				Consistently(func() error {
-					m := &machinev1.Machine{}
-					return k8sClient.Get(ctx, key, m)
-				}).Should(Succeed())
-			})
-		})
-
-		Context("and the poll URL cannot be reached", func() {
-			BeforeEach(func() {
-				h.pollURL = &url.URL{Opaque: "abc#1://localhost"}
+			JustBeforeEach(func() {
+				// Ensure the polling logic is excercised in tests
+				for atomic.LoadInt32(&counter) < 4 {
+					continue
+				}
 			})
 
-			It("should return an error", func() {
-				Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
+			Context("and the handler is stopped", func() {
+				JustBeforeEach(func() {
+					close(stop)
+				})
+
+				It("should not return an error", func() {
+					Eventually(errs).Should(Receive(BeNil()))
+				})
+
+				It("should not delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Consistently(func() error {
+						m := &machinev1.Machine{}
+						return k8sClient.Get(ctx, key, m)
+					}).Should(Succeed())
+				})
 			})
 
-			It("should not delete the machine", func() {
-				key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-				Consistently(func() error {
-					m := &machinev1.Machine{}
-					return k8sClient.Get(ctx, key, m)
-				}).Should(Succeed())
+			Context("and the instance termination notice is fulfilled", func() {
+				It("should delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Eventually(func() error {
+						m := &machinev1.Machine{}
+						err := k8sClient.Get(ctx, key, m)
+						if err != nil && errors.IsNotFound(err) {
+							return nil
+						} else if err != nil {
+							return err
+						}
+						return fmt.Errorf("machine not yet deleted")
+					}).Should(Succeed())
+				})
+			})
+
+			Context("and the instance termination notice is not fulfilled", func() {
+				BeforeEach(func() {
+					httpHandler = newMockHTTPHandler(notPreempted)
+				})
+
+				It("should not delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Consistently(func() error {
+						m := &machinev1.Machine{}
+						return k8sClient.Get(ctx, key, m)
+					}).Should(Succeed())
+				})
+			})
+
+			Context("and the poll URL cannot be reached", func() {
+				BeforeEach(func() {
+					h.pollURL = &url.URL{Opaque: "abc#1://localhost"}
+				})
+
+				It("should return an error", func() {
+					Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
+				})
+
+				It("should not delete the machine", func() {
+					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
+					Consistently(func() error {
+						m := &machinev1.Machine{}
+						return k8sClient.Get(ctx, key, m)
+					}).Should(Succeed())
+				})
 			})
 		})
 	})

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -51,12 +51,15 @@ var _ = Describe("Handler Suite", func() {
 		nodeName = "test-node"
 		httpHandler = newMockHTTPHandler(notPreempted)
 
-		h = &handler{
-			client:       k8sClient,
-			pollInterval: 100 * time.Millisecond,
-			nodeName:     nodeName,
-			log:          klogr.New(),
-		}
+		// use NewHandler() instead of manual construction in order to test NewHandler() logic
+		// like checking that machine api is added to scheme
+		handlerInterface, err := NewHandler(klogr.New(), cfg, 100*time.Millisecond, "", nodeName)
+		Expect(err).ToNot(HaveOccurred())
+
+		h = handlerInterface.(*handler)
+
+		// set pollURL so we can override initial value later
+		h.pollURL = nil
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
This ensures that we are passing the scheme we are adding the machine api to, into the client. It also fixes the scheme import so that we use the standard client-go scheme instead of the kubectl scheme