### PR TITLE
Add tests for actuator events

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/cluster-api-provider-gcp/pkg/apis"
 	"github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/machine"
 	machinesetcontroller "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/machineset"
+	computeservice "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
 	"github.com/openshift/cluster-api-provider-gcp/pkg/version"
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	capimachine "github.com/openshift/machine-api-operator/pkg/controller/machine"
@@ -99,8 +100,9 @@ func main() {
 
 	// Initialize machine actuator.
 	machineActuator := machine.NewActuator(machine.ActuatorParams{
-		CoreClient:    mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("gcpcontroller"),
+		CoreClient:           mgr.GetClient(),
+		EventRecorder:        mgr.GetEventRecorderFor("gcpcontroller"),
+		ComputeClientBuilder: computeservice.NewComputeService,
 	})
 
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {

--- a/pkg/cloud/gcp/actuators/machine/actuator.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator.go
@@ -56,6 +56,7 @@ func (a *Actuator) handleMachineError(machine *machinev1.Machine, err error, eve
 func (a *Actuator) Create(ctx context.Context, machine *machinev1.Machine) error {
 	klog.Infof("%s: Creating machine", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
+		Context:    ctx,
 		coreClient: a.coreClient,
 		machine:    machine,
 	})
@@ -74,6 +75,7 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1.Machine) error
 func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool, error) {
 	klog.Infof("%s: Checking if machine exists", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
+		Context:    ctx,
 		coreClient: a.coreClient,
 		machine:    machine,
 	})
@@ -91,6 +93,7 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool
 func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error {
 	klog.Infof("%s: Updating machine", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
+		Context:    ctx,
 		coreClient: a.coreClient,
 		machine:    machine,
 	})
@@ -110,6 +113,7 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error
 func (a *Actuator) Delete(ctx context.Context, machine *machinev1.Machine) error {
 	klog.Infof("%s: Deleting machine", machine.Name)
 	scope, err := newMachineScope(machineScopeParams{
+		Context:    ctx,
 		coreClient: a.coreClient,
 		machine:    machine,
 	})

--- a/pkg/cloud/gcp/actuators/machine/actuator_test.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator_test.go
@@ -1,12 +1,26 @@
 package machine
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
 	"testing"
+	"time"
 
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
+	computeservice "github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 func init() {
@@ -14,17 +28,248 @@ func init() {
 	machinev1.AddToScheme(scheme.Scheme)
 }
 
-func TestActuatorCreate(t *testing.T) {
-	eventsChannel := make(chan string, 1)
-	recorder := &record.FakeRecorder{
-		Events: eventsChannel,
+func TestActuatorEvents(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 10 * time.Second
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "..", "config", "crds")},
 	}
-	// Initialize machine actuator.
-	machineActuator := NewActuator(ActuatorParams{
-		CoreClient:    fake.NewFakeClient(),
-		EventRecorder: recorder,
+
+	cfg, err := testEnv.Start()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg).ToNot(BeNil())
+	defer func() {
+		g.Expect(testEnv.Stop()).To(Succeed())
+	}()
+
+	mgr, err := manager.New(cfg, manager.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
 	})
-	if machineActuator == nil {
-		t.Errorf("expected machine not nil")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doneMgr := make(chan struct{})
+	defer close(doneMgr)
+
+	go func() {
+		g.Expect(mgr.Start(doneMgr)).To(Succeed())
+	}()
+
+	k8sClient := mgr.GetClient()
+	eventRecorder := mgr.GetEventRecorderFor("vspherecontroller")
+
+	userDataSecretName := "user-data-test"
+	credentialsSecretName := "credentials-test"
+	defaultNamespaceName := "test"
+	credentialsSecretKey := "service_account.json"
+
+	defaultNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultNamespaceName,
+		},
+	}
+	g.Expect(k8sClient.Create(context.Background(), defaultNamespace)).To(Succeed())
+	defer func() {
+		g.Expect(k8sClient.Delete(context.Background(), defaultNamespace)).To(Succeed())
+	}()
+
+	userDataSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userDataSecretName,
+			Namespace: defaultNamespaceName,
+		},
+		Data: map[string][]byte{
+			userDataSecretKey: []byte("userDataBlob"),
+		},
+	}
+
+	g.Expect(k8sClient.Create(context.Background(), userDataSecret)).To(Succeed())
+	defer func() {
+		g.Expect(k8sClient.Delete(context.Background(), userDataSecret)).To(Succeed())
+	}()
+
+	credentialsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credentialsSecretName,
+			Namespace: defaultNamespaceName,
+		},
+		Data: map[string][]byte{
+			credentialsSecretKey: []byte("{\"project_id\": \"test\"}"),
+		},
+	}
+
+	g.Expect(k8sClient.Create(context.Background(), credentialsSecret)).To(Succeed())
+	defer func() {
+		g.Expect(k8sClient.Delete(context.Background(), credentialsSecret)).To(Succeed())
+	}()
+
+	providerSpec, err := v1beta1.RawExtensionFromProviderSpec(&v1beta1.GCPMachineProviderSpec{
+		CredentialsSecret: &corev1.LocalObjectReference{
+			Name: credentialsSecretName,
+		},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(providerSpec).ToNot(BeNil())
+
+	cases := []struct {
+		name      string
+		error     string
+		operation func(actuator *Actuator, machine *machinev1.Machine)
+		event     string
+	}{
+		{
+			name: "Create machine event failed on invalid machine scope",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				machine.Spec = machinev1.MachineSpec{
+					ProviderSpec: machinev1.ProviderSpec{
+						Value: &runtime.RawExtension{
+							Raw: []byte{'1'},
+						},
+					},
+				}
+				actuator.Create(context.Background(), machine)
+			},
+			event: "test: failed to create scope for machine: failed to get machine config: error unmarshalling providerSpec: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go value of type v1beta1.GCPMachineProviderSpec",
+		},
+		{
+			name: "Create machine event failed, reconciler's create failed",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				machine.Labels[machinev1.MachineClusterIDLabel] = ""
+				actuator.Create(context.Background(), machine)
+			},
+			event: "test: reconciler failed to Create machine: failed validating machine provider spec: machine is missing \"machine.openshift.io/cluster-api-cluster\" label",
+		},
+		{
+			name: "Create machine event succeed",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				actuator.Create(context.Background(), machine)
+			},
+			event: "Created Machine test",
+		},
+		{
+			name: "Update machine event failed on invalid machine scope",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				machine.Spec = machinev1.MachineSpec{
+					ProviderSpec: machinev1.ProviderSpec{
+						Value: &runtime.RawExtension{
+							Raw: []byte{'1'},
+						},
+					},
+				}
+				actuator.Update(context.Background(), machine)
+			},
+			event: "test: failed to create scope for machine: failed to get machine config: error unmarshalling providerSpec: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go value of type v1beta1.GCPMachineProviderSpec",
+		},
+		{
+			name: "Update machine event failed, reconciler's update failed",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				machine.Labels[machinev1.MachineClusterIDLabel] = ""
+				actuator.Update(context.Background(), machine)
+			},
+			event: "test: reconciler failed to Update machine: failed validating machine provider spec: machine is missing \"machine.openshift.io/cluster-api-cluster\" label",
+		},
+		{
+			name: "Update machine event succeed and only one event is created",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				actuator.Update(context.Background(), machine)
+				actuator.Update(context.Background(), machine)
+			},
+			event: "Updated Machine test",
+		},
+		{
+			name: "Delete machine event failed on invalid machine scope",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				machine.Spec = machinev1.MachineSpec{
+					ProviderSpec: machinev1.ProviderSpec{
+						Value: &runtime.RawExtension{
+							Raw: []byte{'1'},
+						},
+					},
+				}
+				actuator.Delete(context.Background(), machine)
+			},
+			event: "test: failed to create scope for machine: failed to get machine config: error unmarshalling providerSpec: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go value of type v1beta1.GCPMachineProviderSpec",
+		},
+		{
+			name: "Delete machine event failed, reconciler's delete failed",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				actuator.Delete(context.Background(), machine)
+			},
+			event: "test: reconciler failed to Delete machine: requeue in: 20s",
+		},
+		{
+			name: "Delete machine event succeed",
+			operation: func(actuator *Actuator, machine *machinev1.Machine) {
+				actuator.computeClientBuilder = computeservice.MockBuilderFuncTypeNotFound
+				actuator.Delete(context.Background(), machine)
+			},
+			event: "Deleted machine test",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
+			machine := &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: defaultNamespaceName,
+					Labels: map[string]string{
+						machinev1.MachineClusterIDLabel: "CLUSTERID",
+					},
+				},
+				Spec: machinev1.MachineSpec{
+					ProviderSpec: machinev1.ProviderSpec{
+						Value: providerSpec,
+					},
+				}}
+
+			// Create the machine
+			gs.Expect(k8sClient.Create(context.Background(), machine)).To(Succeed())
+			defer func() {
+				gs.Expect(k8sClient.Delete(context.Background(), machine)).To(Succeed())
+			}()
+
+			// Ensure the machine has synced to the cache
+			getMachine := func() error {
+				machineKey := types.NamespacedName{Namespace: machine.Namespace, Name: machine.Name}
+				return k8sClient.Get(context.Background(), machineKey, machine)
+			}
+			gs.Eventually(getMachine, timeout).Should(Succeed())
+
+			params := ActuatorParams{
+				CoreClient:           k8sClient,
+				EventRecorder:        eventRecorder,
+				ComputeClientBuilder: computeservice.MockBuilderFuncType,
+			}
+
+			actuator := NewActuator(params)
+			tc.operation(actuator, machine)
+
+			eventList := &v1.EventList{}
+			waitForEvent := func() error {
+				err := k8sClient.List(context.Background(), eventList, client.InNamespace(machine.Namespace))
+				if err != nil {
+					return err
+				}
+
+				if len(eventList.Items) != 1 {
+					return fmt.Errorf("expected len 1, got %d", len(eventList.Items))
+				}
+				return nil
+			}
+
+			gs.Eventually(waitForEvent, timeout).Should(Succeed())
+
+			gs.Expect(eventList.Items[0].Message).To(Equal(tc.event))
+
+			for i := range eventList.Items {
+				gs.Expect(k8sClient.Delete(context.Background(), &eventList.Items[i])).To(Succeed())
+			}
+		})
 	}
 }

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -168,6 +168,10 @@ func (r *Reconciler) create() error {
 }
 
 func (r *Reconciler) update() error {
+	if err := validateMachine(*r.machine, *r.providerSpec); err != nil {
+		return machinecontroller.InvalidMachineConfiguration("failed validating machine provider spec: %v", err)
+	}
+
 	// Add target pools, if necessary
 	if err := r.processTargetPools(true, r.addInstanceToTargetPool); err != nil {
 		return err

--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
-	"google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,12 +167,7 @@ func (r *Reconciler) getRealGCPService(namespace string, providerConfig provider
 		return nil, err
 	}
 
-	oauthClient, err := util.CreateOauth2Client(serviceAccountJSON, compute.CloudPlatformScope)
-	if err != nil {
-		return nil, mapierrors.InvalidMachineConfiguration("error creating oauth client: %v", err)
-	}
-
-	computeService, err := computeservice.NewComputeService(oauthClient)
+	computeService, err := computeservice.NewComputeService(serviceAccountJSON)
 	if err != nil {
 		return nil, mapierrors.InvalidMachineConfiguration("error creating compute service: %v", err)
 	}

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -1,8 +1,7 @@
 package computeservice
 
 import (
-	"net/http"
-
+	"github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 	"github.com/openshift/cluster-api-provider-gcp/pkg/version"
 	"google.golang.org/api/compute/v1"
 )
@@ -26,13 +25,22 @@ type computeService struct {
 	service *compute.Service
 }
 
+// BuilderFuncType is function type for building gcp client
+type BuilderFuncType func(serviceAccountJSON string) (GCPComputeService, error)
+
 // NewComputeService return a new computeService
-func NewComputeService(oauthClient *http.Client) (*computeService, error) {
+func NewComputeService(serviceAccountJSON string) (GCPComputeService, error) {
+	oauthClient, err := util.CreateOauth2Client(serviceAccountJSON, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
 	service, err := compute.New(oauthClient)
 	if err != nil {
 		return nil, err
 	}
 	service.UserAgent = "gcpprovider.openshift.io/" + version.Version.String()
+
 	return &computeService{
 		service: service,
 	}, nil


### PR DESCRIPTION
This PR adds tests for actuator events, but this required couple of other changes.
1. Pass context to machine scope
2. Improve error formatting and make it consistent with other providers
3. Add GCP client builder, similar to what we have in AWS. This allows mocking the client in a cleaner way.
4. Validate machine labels in update()

https://github.com/openshift/machine-api-operator/blob/master/pkg/controller/vsphere/actuator_test.go
https://github.com/openshift/cluster-api-provider-aws/blob/master/pkg/actuators/machine/actuator_test.go