### PR TITLE
 Make termination handler subscription based

### DIFF
--- a/cmd/termination-handler/main.go
+++ b/cmd/termination-handler/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/openshift/cluster-api-provider-gcp/pkg/termination"
 	"github.com/openshift/cluster-api-provider-gcp/pkg/version"
@@ -37,7 +36,7 @@ func main() {
 	klog.InitFlags(nil)
 	logger := klogr.New()
 
-	pollIntervalSeconds := flag.Int64("poll-interval-seconds", 5, "interval in seconds at which termination notice endpoint should be checked (Default: 5)")
+	_ = flag.Int64("poll-interval-seconds", 5, "interval in seconds at which termination notice endpoint should be checked (Default: 5)")
 	nodeName := flag.String("node-name", "", "name of the node that the termination handler is running on")
 	namespace := flag.String("namespace", "", "namespace that the machine for the node should live in. If unspecified, look for machines across all namespaces.")
 	flag.Set("logtostderr", "true")
@@ -55,11 +54,8 @@ func main() {
 		return
 	}
 
-	// Get the poll interval as a duration from the `poll-interval-seconds` flag
-	pollInterval := time.Duration(*pollIntervalSeconds) * time.Second
-
 	// Construct a termination handler
-	handler, err := termination.NewHandler(logger, cfg, pollInterval, *namespace, *nodeName)
+	handler, err := termination.NewHandler(logger, cfg, *namespace, *nodeName)
 	if err != nil {
 		logger.Error(err, "Error constructing termination handler")
 		return

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/cluster-api-provider-gcp
 go 1.13
 
 require (
+	cloud.google.com/go v0.38.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.12.0
@@ -18,7 +19,6 @@ require (
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2
 	k8s.io/klog v1.0.0
-	k8s.io/kubectl v0.18.0-rc.1
 	sigs.k8s.io/controller-runtime v0.6.0
 	sigs.k8s.io/controller-tools v0.3.0
 	sigs.k8s.io/yaml v1.2.0


### PR DESCRIPTION
Use google compute metadata service to watch termination event and utilize the callback method, which would trigger machine deletion.

This PR brings no significant changes to existing polling algorithm, delegates this task to the server. The overall polling URL does not change, but the response time to the metadata changes is quicker.

This is important, as this termination handler is our only guarantee, that the node won't freeze with all scheduled pods, once the spot instance is terminated. As the termination handler thanks to `DaemonSet` is running on the same instance, which should be watched for preemption, it's sudden stop will be devastating to the overall cluster health.

This PR is following recommended practices mentioned in https://github.com/openshift/cluster-api-provider-gcp/issues/112