### PR TITLE
BUG 1867262: Support networks shared from a different project

### DIFF
--- a/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -66,6 +66,7 @@ type GCPMetadata struct {
 type GCPNetworkInterface struct {
 	PublicIP   bool   `json:"publicIP,omitempty"`
 	Network    string `json:"network,omitempty"`
+	ProjectID  string `json:"projectID,omitempty"`
 	Subnetwork string `json:"subnetwork,omitempty"`
 }
 

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -96,15 +96,15 @@ func (r *Reconciler) create() error {
 		computeNIC := &compute.NetworkInterface{
 			AccessConfigs: accessConfigs,
 		}
+		projectID := nic.ProjectID
+		if projectID == "" {
+			projectID = r.projectID
+		}
 		if len(nic.Network) != 0 {
-			projectID := nic.ProjectID
-			if projectID == "" {
-				projectID = r.projectID
-			}
 			computeNIC.Network = fmt.Sprintf("projects/%s/global/networks/%s", projectID, nic.Network)
 		}
 		if len(nic.Subnetwork) != 0 {
-			computeNIC.Subnetwork = fmt.Sprintf("regions/%s/subnetworks/%s", r.providerSpec.Region, nic.Subnetwork)
+			computeNIC.Subnetwork = fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", projectID, r.providerSpec.Region, nic.Subnetwork)
 		}
 		networkInterfaces = append(networkInterfaces, computeNIC)
 	}

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -97,7 +97,11 @@ func (r *Reconciler) create() error {
 			AccessConfigs: accessConfigs,
 		}
 		if len(nic.Network) != 0 {
-			computeNIC.Network = fmt.Sprintf("projects/%s/global/networks/%s", r.projectID, nic.Network)
+			projectID := nic.ProjectID
+			if projectID == "" {
+				projectID = r.projectID
+			}
+			computeNIC.Network = fmt.Sprintf("projects/%s/global/networks/%s", projectID, nic.Network)
 		}
 		if len(nic.Subnetwork) != 0 {
 			computeNIC.Subnetwork = fmt.Sprintf("regions/%s/subnetworks/%s", r.providerSpec.Region, nic.Subnetwork)

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -99,10 +99,12 @@ func TestCreate(t *testing.T) {
 			name: "Use projectID from NetworkInterface if set",
 			providerSpec: &gcpv1beta1.GCPMachineProviderSpec{
 				ProjectID: "project",
+				Region:    "test-region",
 				NetworkInterfaces: []*gcpv1beta1.GCPNetworkInterface{
 					{
-						ProjectID: "network-project",
-						Network:   "test-network",
+						ProjectID:  "network-project",
+						Network:    "test-network",
+						Subnetwork: "test-subnetwork",
 					},
 				},
 			},
@@ -114,15 +116,21 @@ func TestCreate(t *testing.T) {
 				if instance.NetworkInterfaces[0].Network != expectedNetwork {
 					t.Errorf("Expected Network: %q, Got Network: %q", expectedNetwork, instance.NetworkInterfaces[0].Network)
 				}
+				expectedSubnetwork := fmt.Sprintf("projects/%s/regions/%s/networks/%s", "network-project", "test-region", "test-network")
+				if instance.NetworkInterfaces[0].Network != expectedNetwork {
+					t.Errorf("Expected Network: %q, Got Network: %q", expectedSubnetwork, instance.NetworkInterfaces[0].Subnetwork)
+				}
 			},
 		},
 		{
 			name: "Use projectID from ProviderSpec if not set in the NetworkInterface",
 			providerSpec: &gcpv1beta1.GCPMachineProviderSpec{
 				ProjectID: "project",
+				Region:    "test-region",
 				NetworkInterfaces: []*gcpv1beta1.GCPNetworkInterface{
 					{
-						Network: "test-network",
+						Network:    "test-network",
+						Subnetwork: "test-subnetwork",
 					},
 				},
 			},
@@ -133,6 +141,10 @@ func TestCreate(t *testing.T) {
 				expectedNetwork := fmt.Sprintf("projects/%s/global/networks/%s", "project", "test-network")
 				if instance.NetworkInterfaces[0].Network != expectedNetwork {
 					t.Errorf("Expected Network: %q, Got Network: %q", expectedNetwork, instance.NetworkInterfaces[0].Network)
+				}
+				expectedSubnetwork := fmt.Sprintf("projects/%s/regions/%s/networks/%s", "project", "test-region", "test-network")
+				if instance.NetworkInterfaces[0].Network != expectedNetwork {
+					t.Errorf("Expected Network: %q, Got Network: %q", expectedSubnetwork, instance.NetworkInterfaces[0].Subnetwork)
 				}
 			},
 		},

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -25,6 +25,7 @@ func TestCreate(t *testing.T) {
 		expectedCondition   *gcpv1beta1.GCPMachineProviderCondition
 		secret              *corev1.Secret
 		mockInstancesInsert func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+		validateInstance    func(t *testing.T, instance *compute.Instance)
 		expectedError       error
 	}{
 		{
@@ -94,11 +95,52 @@ func TestCreate(t *testing.T) {
 				return nil, &googleapi.Error{Message: "error", Code: 400}
 			},
 		},
+		{
+			name: "Use projectID from NetworkInterface if set",
+			providerSpec: &gcpv1beta1.GCPMachineProviderSpec{
+				ProjectID: "project",
+				NetworkInterfaces: []*gcpv1beta1.GCPNetworkInterface{
+					{
+						ProjectID: "network-project",
+						Network:   "test-network",
+					},
+				},
+			},
+			validateInstance: func(t *testing.T, instance *compute.Instance) {
+				if len(instance.NetworkInterfaces) != 1 {
+					t.Errorf("expected one network interface, got %d", len(instance.NetworkInterfaces))
+				}
+				expectedNetwork := fmt.Sprintf("projects/%s/global/networks/%s", "network-project", "test-network")
+				if instance.NetworkInterfaces[0].Network != expectedNetwork {
+					t.Errorf("Expected Network: %q, Got Network: %q", expectedNetwork, instance.NetworkInterfaces[0].Network)
+				}
+			},
+		},
+		{
+			name: "Use projectID from ProviderSpec if not set in the NetworkInterface",
+			providerSpec: &gcpv1beta1.GCPMachineProviderSpec{
+				ProjectID: "project",
+				NetworkInterfaces: []*gcpv1beta1.GCPNetworkInterface{
+					{
+						Network: "test-network",
+					},
+				},
+			},
+			validateInstance: func(t *testing.T, instance *compute.Instance) {
+				if len(instance.NetworkInterfaces) != 1 {
+					t.Errorf("expected one network interface, got %d", len(instance.NetworkInterfaces))
+				}
+				expectedNetwork := fmt.Sprintf("projects/%s/global/networks/%s", "project", "test-network")
+				if instance.NetworkInterfaces[0].Network != expectedNetwork {
+					t.Errorf("Expected Network: %q, Got Network: %q", expectedNetwork, instance.NetworkInterfaces[0].Network)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, mockComputeService := computeservice.NewComputeServiceMock()
+			receivedInstance, mockComputeService := computeservice.NewComputeServiceMock()
 			providerSpec := &gcpv1beta1.GCPMachineProviderSpec{}
 			labels := map[string]string{
 				machinev1beta1.MachineClusterIDLabel: "CLUSTERID",
@@ -124,6 +166,7 @@ func TestCreate(t *testing.T) {
 				providerSpec:   providerSpec,
 				providerStatus: &gcpv1beta1.GCPMachineProviderStatus{},
 				computeService: mockComputeService,
+				projectID:      providerSpec.ProjectID,
 			}
 
 			reconciler := newReconciler(&machineScope)
@@ -164,6 +207,10 @@ func TestCreate(t *testing.T) {
 				if err != nil {
 					t.Errorf("reconciler was not expected to return error: %v", err)
 				}
+			}
+
+			if tc.validateInstance != nil {
+				tc.validateInstance(t, receivedInstance)
 			}
 		})
 	}


### PR DESCRIPTION
This allows users to specify an alternative project for the network that the VM is created within. This allows for shared VPCs.

I have yet to test this in a real cluster, I want to verify this works before allowing it to merge, hence holding. This shouldn't block the review process though.

/hold