### PR TITLE
Updating ose-gcp-machine-controllers builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,10 +1,10 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-api-provider-gcp
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
  && make build GOPROXY=off NO_DOCKER=1 CGO_ENABLED=0
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-gcp/bin/machine-controller-manager /
 COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-gcp/bin/termination-handler /


### PR DESCRIPTION
Updating ose-gcp-machine-controllers builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-gcp-machine-controllers.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.