### PR TITLE
[OCPCLOUD-809] Add verify-diff check in generate task and enable in CI 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ vendor:
 	go mod verify
 
 .PHONY: generate
-generate:
+generate: gogen goimports
+	./hack/verify-diff.sh
+
+gogen:
 	go generate ./pkg/... ./cmd/...
 
 .PHONY: fmt

--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,0 +1,9 @@
+FILE_DIFF=$(git ls-files -o --exclude-standard)
+
+if [ "$FILE_DIFF" != "" ]; then
+  echo "Found untracked files:"
+  echo $FILE_DIFF
+  exit 1
+fi
+
+git diff --exit-code


### PR DESCRIPTION
Allowing automatic make generate checks in CI. It allows to keep track of API changes, client-generated code updates on each PR.

This PR is dependent on openshift/release#13400 to enable the functionality in CI.