### PR TITLE
Bug 1907286: Ensure Machine is marked interruptible as well as Node

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -268,6 +268,9 @@ func (r *Reconciler) setMachineCloudProviderSpecifics(instance *compute.Instance
 	r.machine.Labels[machinecontroller.MachineAZLabelName] = r.providerSpec.Zone
 
 	if r.providerSpec.Preemptible {
+		// Label on the Machine so that an MHC can select Preemptible instances
+		r.machine.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
+
 		if r.machine.Spec.Labels == nil {
 			r.machine.Spec.Labels = make(map[string]string)
 		}


### PR DESCRIPTION
To enable the termination handler MHC to work, we need to label the Machine as well as the Node as interruptible.