### PR TITLE
Bug 1934021: Ensure response body is closed when we are finished with the request

### DIFF
--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -104,6 +104,9 @@ func (h *handler) run(ctx context.Context) error {
 		req.Header.Add("Metadata-Flavor", "Google")
 
 		resp, err := http.DefaultClient.Do(req)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
 		if err != nil {
 			return false, fmt.Errorf("could not get URL %q: %w", h.pollURL.String(), err)
 		}


### PR DESCRIPTION
When creating an http request in go, this sets two goroutines in the background running. If the body is not closed properly, these goroutines are leaked. This leads to a gradual increase in memory used by the application over time. We must ensure we always close response bodies