### PR TITLE
update golang.org/x/oauth2 to support gcp workload identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20210816181336-8ff39b776da3
 	github.com/openshift/machine-api-operator v0.2.1-0.20210820103535-d50698c302f5
-	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
+	golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6
 	google.golang.org/api v0.44.0
 	k8s.io/api v0.22.0
 	k8s.io/apimachinery v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1024,8 +1024,9 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 h1:0Ja1LBD+yisY6RWM/BH7TJVXWsSjs2VwBSmvSX4HdBc=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6 h1:pERGha6IgvMUdN6oJbwjZTt1ai5/O855Qmv1Bsc0v18=
+golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -1,9 +1,12 @@
 package computeservice
 
 import (
-	"github.com/openshift/cluster-api-provider-gcp/pkg/cloud/gcp/actuators/util"
+	"context"
+
 	"github.com/openshift/cluster-api-provider-gcp/pkg/version"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 )
 
 // GCPComputeService is a pass through wrapper for google.golang.org/api/compute/v1/compute
@@ -30,12 +33,14 @@ type BuilderFuncType func(serviceAccountJSON string) (GCPComputeService, error)
 
 // NewComputeService return a new computeService
 func NewComputeService(serviceAccountJSON string) (GCPComputeService, error) {
-	oauthClient, err := util.CreateOauth2Client(serviceAccountJSON, compute.CloudPlatformScope)
+	ctx := context.TODO()
+
+	creds, err := google.CredentialsFromJSON(ctx, []byte(serviceAccountJSON), compute.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
 
-	service, err := compute.New(oauthClient)
+	service, err := compute.NewService(ctx, option.WithCredentials(creds))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/golang.org/x/oauth2/authhandler/authhandler.go
+++ b/vendor/golang.org/x/oauth2/authhandler/authhandler.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package authhandler implements a TokenSource to support
+// "three-legged OAuth 2.0" via a custom AuthorizationHandler.
+package authhandler
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/oauth2"
+)
+
+// AuthorizationHandler is a 3-legged-OAuth helper that prompts
+// the user for OAuth consent at the specified auth code URL
+// and returns an auth code and state upon approval.
+type AuthorizationHandler func(authCodeURL string) (code string, state string, err error)
+
+// TokenSource returns an oauth2.TokenSource that fetches access tokens
+// using 3-legged-OAuth flow.
+//
+// The provided context.Context is used for oauth2 Exchange operation.
+//
+// The provided oauth2.Config should be a full configuration containing AuthURL,
+// TokenURL, and Scope.
+//
+// An environment-specific AuthorizationHandler is used to obtain user consent.
+//
+// Per the OAuth protocol, a unique "state" string should be specified here.
+// This token source will verify that the "state" is identical in the request
+// and response before exchanging the auth code for OAuth token to prevent CSRF
+// attacks.
+func TokenSource(ctx context.Context, config *oauth2.Config, state string, authHandler AuthorizationHandler) oauth2.TokenSource {
+	return oauth2.ReuseTokenSource(nil, authHandlerSource{config: config, ctx: ctx, authHandler: authHandler, state: state})
+}
+
+type authHandlerSource struct {
+	ctx         context.Context
+	config      *oauth2.Config
+	authHandler AuthorizationHandler
+	state       string
+}
+
+func (source authHandlerSource) Token() (*oauth2.Token, error) {
+	url := source.config.AuthCodeURL(source.state)
+	code, state, err := source.authHandler(url)
+	if err != nil {
+		return nil, err
+	}
+	if state != source.state {
+		return nil, errors.New("state mismatch in 3-legged-OAuth flow")
+	}
+	return source.config.Exchange(source.ctx, code)
+}

--- a/vendor/golang.org/x/oauth2/google/default.go
+++ b/vendor/golang.org/x/oauth2/google/default.go
@@ -16,6 +16,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/authhandler"
 )
 
 // Credentials holds Google credentials, including "Application Default Credentials".
@@ -41,6 +42,32 @@ type Credentials struct {
 // Deprecated: use Credentials instead.
 type DefaultCredentials = Credentials
 
+// CredentialsParams holds user supplied parameters that are used together
+// with a credentials file for building a Credentials object.
+type CredentialsParams struct {
+	// Scopes is the list OAuth scopes. Required.
+	// Example: https://www.googleapis.com/auth/cloud-platform
+	Scopes []string
+
+	// Subject is the user email used for domain wide delegation (see
+	// https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority).
+	// Optional.
+	Subject string
+
+	// AuthHandler is the AuthorizationHandler used for 3-legged OAuth flow. Optional.
+	AuthHandler authhandler.AuthorizationHandler
+
+	// State is a unique string used with AuthHandler. Optional.
+	State string
+}
+
+func (params CredentialsParams) deepCopy() CredentialsParams {
+	paramsCopy := params
+	paramsCopy.Scopes = make([]string, len(params.Scopes))
+	copy(paramsCopy.Scopes, params.Scopes)
+	return paramsCopy
+}
+
 // DefaultClient returns an HTTP Client that uses the
 // DefaultTokenSource to obtain authentication credentials.
 func DefaultClient(ctx context.Context, scope ...string) (*http.Client, error) {
@@ -62,7 +89,7 @@ func DefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSourc
 	return creds.TokenSource, nil
 }
 
-// FindDefaultCredentials searches for "Application Default Credentials".
+// FindDefaultCredentialsWithParams searches for "Application Default Credentials".
 //
 // It looks for credentials in the following places,
 // preferring the first location found:
@@ -81,11 +108,14 @@ func DefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSourc
 //   4. On Google Compute Engine, Google App Engine standard second generation runtimes
 //      (>= Go 1.11), and Google App Engine flexible environment, it fetches
 //      credentials from the metadata server.
-func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials, error) {
+func FindDefaultCredentialsWithParams(ctx context.Context, params CredentialsParams) (*Credentials, error) {
+	// Make defensive copy of the slices in params.
+	params = params.deepCopy()
+
 	// First, try the environment variable.
 	const envVar = "GOOGLE_APPLICATION_CREDENTIALS"
 	if filename := os.Getenv(envVar); filename != "" {
-		creds, err := readCredentialsFile(ctx, filename, scopes)
+		creds, err := readCredentialsFile(ctx, filename, params)
 		if err != nil {
 			return nil, fmt.Errorf("google: error getting credentials using %v environment variable: %v", envVar, err)
 		}
@@ -94,7 +124,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 
 	// Second, try a well-known file.
 	filename := wellKnownFile()
-	if creds, err := readCredentialsFile(ctx, filename, scopes); err == nil {
+	if creds, err := readCredentialsFile(ctx, filename, params); err == nil {
 		return creds, nil
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("google: error getting credentials using well-known file (%v): %v", filename, err)
@@ -106,7 +136,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 	if appengineTokenFunc != nil {
 		return &DefaultCredentials{
 			ProjectID:   appengineAppIDFunc(ctx),
-			TokenSource: AppEngineTokenSource(ctx, scopes...),
+			TokenSource: AppEngineTokenSource(ctx, params.Scopes...),
 		}, nil
 	}
 
@@ -116,7 +146,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 		id, _ := metadata.ProjectID()
 		return &DefaultCredentials{
 			ProjectID:   id,
-			TokenSource: ComputeTokenSource("", scopes...),
+			TokenSource: ComputeTokenSource("", params.Scopes...),
 		}, nil
 	}
 
@@ -125,18 +155,38 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 	return nil, fmt.Errorf("google: could not find default credentials. See %v for more information.", url)
 }
 
-// CredentialsFromJSON obtains Google credentials from a JSON value. The JSON can
-// represent either a Google Developers Console client_credentials.json file (as in
-// ConfigFromJSON), a Google Developers service account key file (as in
-// JWTConfigFromJSON) or the JSON configuration file for workload identity federation
-// in non-Google cloud platforms (see
-// https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation).
-func CredentialsFromJSON(ctx context.Context, jsonData []byte, scopes ...string) (*Credentials, error) {
+// FindDefaultCredentials invokes FindDefaultCredentialsWithParams with the specified scopes.
+func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials, error) {
+	var params CredentialsParams
+	params.Scopes = scopes
+	return FindDefaultCredentialsWithParams(ctx, params)
+}
+
+// CredentialsFromJSONWithParams obtains Google credentials from a JSON value. The JSON can
+// represent either a Google Developers Console client_credentials.json file (as in ConfigFromJSON),
+// a Google Developers service account key file, a gcloud user credentials file (a.k.a. refresh
+// token JSON), or the JSON configuration file for workload identity federation in non-Google cloud
+// platforms (see https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation).
+func CredentialsFromJSONWithParams(ctx context.Context, jsonData []byte, params CredentialsParams) (*Credentials, error) {
+	// Make defensive copy of the slices in params.
+	params = params.deepCopy()
+
+	// First, attempt to parse jsonData as a Google Developers Console client_credentials.json.
+	config, _ := ConfigFromJSON(jsonData, params.Scopes...)
+	if config != nil {
+		return &Credentials{
+			ProjectID:   "",
+			TokenSource: authhandler.TokenSource(ctx, config, params.State, params.AuthHandler),
+			JSON:        jsonData,
+		}, nil
+	}
+
+	// Otherwise, parse jsonData as one of the other supported credentials files.
 	var f credentialsFile
 	if err := json.Unmarshal(jsonData, &f); err != nil {
 		return nil, err
 	}
-	ts, err := f.tokenSource(ctx, append([]string(nil), scopes...))
+	ts, err := f.tokenSource(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -147,6 +197,13 @@ func CredentialsFromJSON(ctx context.Context, jsonData []byte, scopes ...string)
 	}, nil
 }
 
+// CredentialsFromJSON invokes CredentialsFromJSONWithParams with the specified scopes.
+func CredentialsFromJSON(ctx context.Context, jsonData []byte, scopes ...string) (*Credentials, error) {
+	var params CredentialsParams
+	params.Scopes = scopes
+	return CredentialsFromJSONWithParams(ctx, jsonData, params)
+}
+
 func wellKnownFile() string {
 	const f = "application_default_credentials.json"
 	if runtime.GOOS == "windows" {
@@ -155,10 +212,10 @@ func wellKnownFile() string {
 	return filepath.Join(guessUnixHomeDir(), ".config", "gcloud", f)
 }
 
-func readCredentialsFile(ctx context.Context, filename string, scopes []string) (*DefaultCredentials, error) {
+func readCredentialsFile(ctx context.Context, filename string, params CredentialsParams) (*DefaultCredentials, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return CredentialsFromJSON(ctx, b, scopes...)
+	return CredentialsFromJSONWithParams(ctx, b, params)
 }

--- a/vendor/golang.org/x/oauth2/google/doc.go
+++ b/vendor/golang.org/x/oauth2/google/doc.go
@@ -4,9 +4,9 @@
 
 // Package google provides support for making OAuth2 authorized and authenticated
 // HTTP requests to Google APIs. It supports the Web server flow, client-side
-// credentials, service accounts, Google Compute Engine service accounts, Google
-// App Engine service accounts and workload identity federation from non-Google
-// cloud platforms.
+// credentials, service accounts, Google Compute Engine service accounts,
+// Google App Engine service accounts and workload identity federation
+// from non-Google cloud platforms.
 //
 // A brief overview of the package follows. For more information, please read
 // https://developers.google.com/accounts/docs/OAuth2

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/aws.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/aws.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 type awsSecurityCredentials struct {
@@ -341,6 +342,9 @@ func (cs awsCredentialSource) subjectToken() (string, error) {
 
 func (cs *awsCredentialSource) getRegion() (string, error) {
 	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
+		return envAwsRegion, nil
+	}
+	if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
 	}
 

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/basecredentials.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/basecredentials.go
@@ -20,15 +20,34 @@ var now = func() time.Time {
 
 // Config stores the configuration for fetching tokens with external credentials.
 type Config struct {
+	// Audience is the Secure Token Service (STS) audience which contains the resource name for the workload
+	// identity pool or the workforce pool and the provider identifier in that pool.
 	Audience                       string
+	// SubjectTokenType is the STS token type based on the Oauth2.0 token exchange spec
+	// e.g. `urn:ietf:params:oauth:token-type:jwt`.
 	SubjectTokenType               string
+	// TokenURL is the STS token exchange endpoint.
 	TokenURL                       string
+	// TokenInfoURL is the token_info endpoint used to retrieve the account related information (
+	// user attributes like account identifier, eg. email, username, uid, etc). This is
+	// needed for gCloud session account identification.
 	TokenInfoURL                   string
+	// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
+	// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
 	ServiceAccountImpersonationURL string
+	// ClientSecret is currently only required if token_info endpoint also
+	// needs to be called with the generated GCP access token. When provided, STS will be
+	// called with additional basic authentication using client_id as username and client_secret as password.
 	ClientSecret                   string
+	// ClientID is only required in conjunction with ClientSecret, as described above.
 	ClientID                       string
+	// CredentialSource contains the necessary information to retrieve the token itself, as well
+	// as some environmental information.
 	CredentialSource               CredentialSource
+	// QuotaProjectID is injected by gCloud. If the value is non-empty, the Auth libraries
+	// will set the x-goog-user-project which overrides the project associated with the credentials.
 	QuotaProjectID                 string
+	// Scopes contains the desired scopes for the returned access token.
 	Scopes                         []string
 }
 
@@ -66,6 +85,8 @@ type format struct {
 }
 
 // CredentialSource stores the information necessary to retrieve the credentials for the STS exchange.
+// Either the File or the URL field should be filled, depending on the kind of credential in question.
+// The EnvironmentID should start with AWS if being used for an AWS credential.
 type CredentialSource struct {
 	File string `json:"file"`
 
@@ -107,7 +128,7 @@ type baseCredentialSource interface {
 	subjectToken() (string, error)
 }
 
-// tokenSource is the source that handles external credentials.
+// tokenSource is the source that handles external credentials.  It is used to retrieve Tokens.
 type tokenSource struct {
 	ctx  context.Context
 	conf *Config

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/clientauth.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/clientauth.go
@@ -19,6 +19,9 @@ type clientAuthentication struct {
 	ClientSecret string
 }
 
+// InjectAuthentication is used to add authentication to a Secure Token Service exchange
+// request.  It modifies either the passed url.Values or http.Header depending on the desired
+// authentication format.
 func (c *clientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {
 	if c.ClientID == "" || c.ClientSecret == "" || values == nil || headers == nil {
 		return

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/impersonate.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/impersonate.go
@@ -36,7 +36,7 @@ type impersonateTokenSource struct {
 	scopes []string
 }
 
-// Token performs the exchange to get a temporary service account
+// Token performs the exchange to get a temporary service account token to allow access to GCP.
 func (its impersonateTokenSource) Token() (*oauth2.Token, error) {
 	reqBody := generateAccessTokenReq{
 		Lifetime: "3600s",

--- a/vendor/golang.org/x/oauth2/google/jwt.go
+++ b/vendor/golang.org/x/oauth2/google/jwt.go
@@ -7,6 +7,7 @@ package google
 import (
 	"crypto/rsa"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -24,6 +25,28 @@ import (
 // optimization supported by a few Google services.
 // Unless you know otherwise, you should use JWTConfigFromJSON instead.
 func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.TokenSource, error) {
+	return newJWTSource(jsonKey, audience, nil)
+}
+
+// JWTAccessTokenSourceWithScope uses a Google Developers service account JSON
+// key file to read the credentials that authorize and authenticate the
+// requests, and returns a TokenSource that does not use any OAuth2 flow but
+// instead creates a JWT and sends that as the access token.
+// The scope is typically a list of URLs that specifies the scope of the
+// credentials.
+//
+// Note that this is not a standard OAuth flow, but rather an
+// optimization supported by a few Google services.
+// Unless you know otherwise, you should use JWTConfigFromJSON instead.
+func JWTAccessTokenSourceWithScope(jsonKey []byte, scope ...string) (oauth2.TokenSource, error) {
+	return newJWTSource(jsonKey, "", scope)
+}
+
+func newJWTSource(jsonKey []byte, audience string, scopes []string) (oauth2.TokenSource, error) {
+	if len(scopes) == 0 && audience == "" {
+		return nil, fmt.Errorf("google: missing scope/audience for JWT access token")
+	}
+
 	cfg, err := JWTConfigFromJSON(jsonKey)
 	if err != nil {
 		return nil, fmt.Errorf("google: could not parse JSON key: %v", err)
@@ -35,6 +58,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 	ts := &jwtAccessTokenSource{
 		email:    cfg.Email,
 		audience: audience,
+		scopes:   scopes,
 		pk:       pk,
 		pkID:     cfg.PrivateKeyID,
 	}
@@ -47,6 +71,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 
 type jwtAccessTokenSource struct {
 	email, audience string
+	scopes          []string
 	pk              *rsa.PrivateKey
 	pkID            string
 }
@@ -54,12 +79,14 @@ type jwtAccessTokenSource struct {
 func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
 	iat := time.Now()
 	exp := iat.Add(time.Hour)
+	scope := strings.Join(ts.scopes, " ")
 	cs := &jws.ClaimSet{
-		Iss: ts.email,
-		Sub: ts.email,
-		Aud: ts.audience,
-		Iat: iat.Unix(),
-		Exp: exp.Unix(),
+		Iss:   ts.email,
+		Sub:   ts.email,
+		Aud:   ts.audience,
+		Scope: scope,
+		Iat:   iat.Unix(),
+		Exp:   exp.Unix(),
 	}
 	hdr := &jws.Header{
 		Algorithm: "RS256",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,9 +243,10 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
-# golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
+# golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6
 ## explicit
 golang.org/x/oauth2
+golang.org/x/oauth2/authhandler
 golang.org/x/oauth2/google
 golang.org/x/oauth2/google/internal/externalaccount
 golang.org/x/oauth2/internal


### PR DESCRIPTION
Workload identity federation will enable short lived credentials in a gcp
cluster. Current version golang.org/x/oauth2 does not support it.

ref: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
docs: https://github.com/openshift/cloud-credential-operator/pull/376