### PR TITLE
Updat golang image to version 1.16 inside Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(NO_DOCKER), 1)
   IMAGE_BUILD_CMD = imagebuilder
   export CGO_ENABLED
 else
-  DOCKER_CMD :=  $(ENGINE) run --rm -e CGO_ENABLED=0 -e GOARCH=$(GOARCH) -e GOOS=$(GOOS) -v "$(PWD)":/go/src/github.com/openshift/cluster-api-provider-gcp:Z -w /go/src/github.com/openshift/cluster-api-provider-gcp openshift/origin-release:golang-1.15
+  DOCKER_CMD :=  $(ENGINE) run --rm -e CGO_ENABLED=0 -e GOARCH=$(GOARCH) -e GOOS=$(GOOS) -v "$(PWD)":/go/src/github.com/openshift/cluster-api-provider-gcp:Z -w /go/src/github.com/openshift/cluster-api-provider-gcp openshift/origin-release:golang-1.16
   IMAGE_BUILD_CMD =  $(ENGINE) build
 endif
 


### PR DESCRIPTION
Current master branch is no longer able to build with golang 1.15, therefore it would be nice to update Makefile to use 1.16 image.