### PR TITLE
Bug 2009111: Fix broken path defaulting for disk image

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -183,7 +183,7 @@ func (r *Reconciler) create() error {
 		srcImage := disk.Image
 		if !strings.Contains(disk.Image, "/") {
 			// only image name provided therefore defaulting to the current project
-			srcImage = googleapi.ResolveRelative(r.computeService.BasePath(), fmt.Sprintf("%s/global/images/%s", r.projectID, disk.Image))
+			srcImage = googleapi.ResolveRelative(r.computeService.BasePath(), fmt.Sprintf("projects/%s/global/images/%s", r.projectID, disk.Image))
 		}
 
 		disks = append(disks, &compute.AttachedDisk{


### PR DESCRIPTION
BasePath was changed in GCP sdk. In c6faa4bae2ca201573c628e92b112971833284e7 sdk was updated.

See ```git diff c6faa4bae2ca201573c628e92b112971833284e7~1..HEAD vendor/google.golang.org/api/compute/v1/compute-gen.go```

```
diff --git a/vendor/google.golang.org/api/compute/v1/compute-gen.go b/vendor/google.golang.org/api/compute/v1/compute-gen.go
index 2f65969c..03fecd97 100644
--- a/vendor/google.golang.org/api/compute/v1/compute-gen.go
+++ b/vendor/google.golang.org/api/compute/v1/compute-gen.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC.
+// Copyright 2021 Google LLC.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -78,11 +78,12 @@ var _ = internaloption.WithDefaultEndpoint
 const apiId = "compute:v1"
 const apiName = "compute"
 const apiVersion = "v1"
-const basePath = "https://compute.googleapis.com/compute/v1/projects/"
+const basePath = "https://compute.googleapis.com/compute/v1/"
+const mtlsBasePath = "https://compute.mtls.googleapis.com/compute/v1/"

...
 ```
