### PR TITLE
OCPCLOUD-1250: add annotation to enable gpu autoscaling

### DIFF
--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -157,17 +157,15 @@ func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, e
 	machineSet.Annotations[cpuKey] = strconv.FormatInt(machineType.GuestCpus, 10)
 	machineSet.Annotations[memoryKey] = strconv.FormatInt(machineType.MemoryMb, 10)
 
-	if (len(providerConfig.GuestAccelerators)) == 0 {
-		if len(machineType.Accelerators) == 0 {
-			machineSet.Annotations[gpuKey] = strconv.FormatInt(0, 10)
-		} else {
-			// Accelerators will always be max size of 1
-			machineSet.Annotations[gpuKey] = strconv.FormatInt(machineType.Accelerators[0].GuestAcceleratorCount, 10)
-		}
-
-	} else {
+	switch {
+	case len(providerConfig.GuestAccelerators) > 0:
 		// Guest accelerators will always be max size of 1
 		machineSet.Annotations[gpuKey] = strconv.FormatInt(providerConfig.GuestAccelerators[0].AcceleratorCount, 10)
+	case len(machineType.Accelerators) > 0:
+		// Accelerators will always be max size of 1
+		machineSet.Annotations[gpuKey] = strconv.FormatInt(machineType.Accelerators[0].GuestAcceleratorCount, 10)
+	default:
+		machineSet.Annotations[gpuKey] = strconv.FormatInt(0, 10)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -39,6 +39,7 @@ const (
 	// https://github.com/openshift/enhancements/pull/186
 	cpuKey    = "machine.openshift.io/vCPU"
 	memoryKey = "machine.openshift.io/memoryMb"
+	gpuKey    = "machine.openshift.io/GPU"
 )
 
 // Reconciler reconciles machineSets.
@@ -155,6 +156,19 @@ func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, e
 	// TODO: get annotations keys from machine API
 	machineSet.Annotations[cpuKey] = strconv.FormatInt(machineType.GuestCpus, 10)
 	machineSet.Annotations[memoryKey] = strconv.FormatInt(machineType.MemoryMb, 10)
+
+	if (len(providerConfig.GuestAccelerators)) == 0 {
+		if len(machineType.Accelerators) == 0 {
+			machineSet.Annotations[gpuKey] = strconv.FormatInt(0, 10)
+		} else {
+			// Accelerators will always be max size of 1
+			machineSet.Annotations[gpuKey] = strconv.FormatInt(machineType.Accelerators[0].GuestAcceleratorCount, 10)
+		}
+
+	} else {
+		// Guest accelerators will always be max size of 1
+		machineSet.Annotations[gpuKey] = strconv.FormatInt(providerConfig.GuestAccelerators[0].AcceleratorCount, 10)
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/cloud/gcp/actuators/machineset/controller_test.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller_test.go
@@ -52,6 +52,16 @@ var mockMachineTypesFunc = func(_ string, _ string, machineType string) (*comput
 			GuestCpus: 16,
 			MemoryMb:  16384,
 		}, nil
+	case "a2-highgpu-2g":
+		return &compute.MachineType{
+			GuestCpus: 24,
+			MemoryMb:  174080,
+			Accelerators: []*compute.MachineTypeAccelerators{
+				{
+					GuestAcceleratorCount: 2,
+				},
+			},
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown machineType: %s", machineType)
 	}
@@ -145,6 +155,7 @@ var _ = Describe("Reconciler", func() {
 			expectedAnnotations: map[string]string{
 				cpuKey:    "2",
 				memoryKey: "7680",
+				gpuKey:    "0",
 			},
 			expectedEvents: []string{},
 		}),
@@ -154,6 +165,17 @@ var _ = Describe("Reconciler", func() {
 			expectedAnnotations: map[string]string{
 				cpuKey:    "16",
 				memoryKey: "16384",
+				gpuKey:    "0",
+			},
+			expectedEvents: []string{},
+		}),
+		Entry("with a a2-highgpu-2g", reconcileTestCase{
+			machineType:         "a2-highgpu-2g",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "24",
+				memoryKey: "174080",
+				gpuKey:    "2",
 			},
 			expectedEvents: []string{},
 		}),
@@ -168,6 +190,7 @@ var _ = Describe("Reconciler", func() {
 				"annother": "existingAnnotation",
 				cpuKey:     "2",
 				memoryKey:  "7680",
+				gpuKey:     "0",
 			},
 			expectedEvents: []string{},
 		}),
@@ -254,6 +277,7 @@ func TestReconcile(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				cpuKey:    "2",
 				memoryKey: "7680",
+				gpuKey:    "0",
 			},
 			expectErr: false,
 		},
@@ -265,6 +289,19 @@ func TestReconcile(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				cpuKey:    "16",
 				memoryKey: "16384",
+				gpuKey:    "0",
+			},
+			expectErr: false,
+		},
+		{
+			name:                "with a a2-highgpu-2g",
+			machineType:         "a2-highgpu-2g",
+			mockMachineTypesGet: mockMachineTypesFunc,
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "24",
+				memoryKey: "174080",
+				gpuKey:    "2",
 			},
 			expectErr: false,
 		},
@@ -281,6 +318,7 @@ func TestReconcile(t *testing.T) {
 				"annother": "existingAnnotation",
 				cpuKey:     "2",
 				memoryKey:  "7680",
+				gpuKey:     "0",
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
Tested with `quay.io/elmiko/busybox` image with `limits: nvidia.com/gpu: 1` as workload for autoscaling tests.