### PR TITLE
OCPBUGS-2135: Add cloud provider label to instances

### DIFF
--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -37,11 +37,11 @@ func (in Labels) HasOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// // HasOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
-// func (in Labels) HasGCPCloudProviderOwned(cluster string) bool {
-// 	value, ok := t[ClusterGCPCloudProviderTagKey(cluster)]
-// 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
-// }
+// HasOwned returns true if the tags contains a tag that marks the resource as owned by the cluster from the perspective of the in-tree cloud provider.
+func (in Labels) HasGCPCloudProviderOwned(cluster string) bool {
+	value, ok := in[ClusterGCPCloudProviderTagKey(cluster)]
+	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
+}
 
 // GetRole returns the Cluster API role for the tagged resource.
 func (in Labels) GetRole() string {
@@ -109,6 +109,14 @@ const (
 	// dedicated to this cluster api provider implementation.
 	NameGCPClusterAPIRole = NameGCPProviderPrefix + "role"
 
+	// NameKubernetesGCPCloudProviderPrefix is the tag name used by the cloud provider to logically
+	// separate independent cluster resources. We use it to identify which resources we expect
+	// to be permissive about state changes.
+	// logically independent clusters running in the same AZ.
+	// The tag key = NameKubernetesGCPCloudProviderPrefix + clusterID
+	// The tag value is an ownership value.
+	NameKubernetesGCPCloudProviderPrefix = "kubernetes-io-cluster-"
+
 	// APIServerRoleTagValue describes the value for the apiserver role.
 	APIServerRoleTagValue = "apiserver"
 )
@@ -119,9 +127,9 @@ func ClusterTagKey(name string) string {
 }
 
 // ClusterGCPCloudProviderTagKey generates the key for resources associated a cluster's GCP cloud provider.
-// func ClusterGCPCloudProviderTagKey(name string) string {
-// return fmt.Sprintf("%s%s", NameKubernetesGCPCloudProviderPrefix, name)
-// }
+func ClusterGCPCloudProviderTagKey(name string) string {
+	return fmt.Sprintf("%s%s", NameKubernetesGCPCloudProviderPrefix, name)
+}
 
 // BuildParams is used to build tags around an gcp resource.
 type BuildParams struct {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -339,8 +339,11 @@ func (m *MachineScope) InstanceSpec() *compute.Instance {
 			ClusterName: m.ClusterGetter.Name(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Role:        pointer.StringPtr(m.Role()),
-			// TODO(vincepri): Check what needs to be added for the cloud provider label.
-			Additional: m.ClusterGetter.AdditionalLabels().AddLabels(m.GCPMachine.Spec.AdditionalLabels),
+			Additional: m.ClusterGetter.AdditionalLabels().AddLabels(m.GCPMachine.Spec.AdditionalLabels).AddLabels(
+				infrav1.Labels{
+					infrav1.ClusterGCPCloudProviderTagKey(m.ClusterGetter.Name()): string(infrav1.ResourceLifecycleOwned),
+				},
+			),
 		}),
 		Scheduling: &compute.Scheduling{
 			Preemptible: m.GCPMachine.Spec.Preemptible,


### PR DESCRIPTION
Adds "kubernetes-io-cluster-\<clusterName\>: owned" label to created instances to enable openshift (un)installer to find and delete instances created by capg. 

This label (with some differences due to character limitations) is added by other providers, but is commented out on GCP for some reason.

NameKubernetesAWSCloudProviderPrefix = "kubernetes.io/cluster/" on AWS
NameKubernetesAzureCloudProviderPrefix = "kubernetes.io_cluster_" on Azure

Alternatively, we could update the installer to also look for "capg-cluster-\<clusterName\>" label that is already being added. 