### PR TITLE
OCPCLOUD-2218: UPSTREAM: 1056: fix: update metadata file to add the 1.5 releases

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,3 +26,6 @@ releaseSeries:
   - major: 1
     minor: 4
     contract: v1beta1
+  - major: 1
+    minor: 5
+    contract: v1beta1

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -54,7 +54,7 @@ providers:
   - name: gcp
     type: InfrastructureProvider
     versions:
-      - name: v1.4.99 # next; use manifest from source files
+      - name: v1.5.99 # next; use manifest from source files
         value: "${PWD}/config/default"
     files:
       - sourcePath: "${PWD}/metadata.yaml"


### PR DESCRIPTION
Temporarily carrying upstream fix (https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1056) to metadata file until next patch release.