### PR TITLE
OCPCLOUD-2256: No-op change to trigger image rebuild

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -17,7 +17,7 @@ ifndef PROVIDER_VERSION
 endif
 
 .PHONY: ocp-manifests
-ocp-manifests: $(RELEASE_DIR) $(KUSTOMIZE) check-env ## Builds openshift specific manifests
+ocp-manifests: $(RELEASE_DIR) $(KUSTOMIZE) check-env ## Builds openshift specific manifests.
 	# Build core-components.
 	$(KUSTOMIZE) build ../config/default > infrastructure-components.yaml
 	# Generate provider manifests.


### PR DESCRIPTION
no-op change to trigger rebuild, following the issues at https://redhat-internal.slack.com/archives/CB95J6R4N/p1701163468934139