### PR TITLE
Revert "OCPBUGS-24076: Updating ose-gcp-cluster-api-controllers-container image to be consistent with ART"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.20-openshift-4.15
+  tag: rhel-8-release-golang-1.20-openshift-4.15

--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 
 WORKDIR /build
 COPY . .
@@ -7,7 +7,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=${GOOS} GOPROXY=${GOPROXY} go build \
   -o=cluster-api-provider-gcp-controller-manager \
   main.go
 
-FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.15:base
 
 LABEL description="Cluster API Provider GCP Controller Manager"
 


### PR DESCRIPTION
Reverts openshift/cluster-api-provider-gcp#210
As that breaks the TP payload putting the CAPG controllers pod in crashloop with `lib64/libc.so.6: version `GLIBC_2.32' not found` due to RHEL8/RHEL9 discrepancies.