### PR TITLE
OCPBUGS-28331: add test directory to snyk excludes

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,3 +5,4 @@ exclude:
   global:
     - "vendor/**"
     - "**/vendor/**"
+    - "test/**"


### PR DESCRIPTION
we do not package or release anything from the test directory and it is safe to exclude from our snyk scans.