### PR TITLE
OCPBUGS-33170: Container fallback to logs on error

### DIFF
--- a/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-gcp.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-gcp.yaml
@@ -2914,6 +2914,7 @@ data:
           containers:
           - args:
             - --leader-elect
+            - --feature-gates=GKE=${EXP_CAPG_GKE:=false}
             - --diagnostics-address=${CAPG_DIAGNOSTICS_ADDRESS:=:8443}
             - --insecure-diagnostics=${CAPG_INSECURE_DIAGNOSTICS:=false}
             - --v=${CAPG_LOGLEVEL:=0}
@@ -2969,6 +2970,7 @@ data:
               privileged: false
               runAsGroup: 65532
               runAsUser: 65532
+            terminationMessagePolicy: FallbackToLogsOnError
             volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.18
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240304144039-3218c094afd5
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -774,6 +774,8 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240304144039-3218c094afd5 h1:GRM6NyGEQ3lBCk2zr89z6SWRF5jj9VeT0y6Kj/oTQXA=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240304144039-3218c094afd5/go.mod h1:fEXzPOnusmda/9L2GJdI/MG0c/dbpzKtMXis096fsRU=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b h1:b61ReGGIAZ83fdElH/Q3DWo9OIFHDR4I2Aubgztife0=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b/go.mod h1:fEXzPOnusmda/9L2GJdI/MG0c/dbpzKtMXis096fsRU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
@@ -234,15 +234,9 @@ func customizeDeployments(obj *unstructured.Unstructured) {
 		if container.Name == "kube-rbac-proxy" {
 			container.Image = "registry.ci.openshift.org/openshift:kube-rbac-proxy"
 		}
-		noFeatureGates := []string{}
-		for _, arg := range container.Args {
-			if !strings.HasPrefix(arg, "--feature-gates=") {
-				noFeatureGates = append(noFeatureGates, arg)
-			}
-		}
-		if len(noFeatureGates) > 0 {
-			container.Args = noFeatureGates
-		}
+
+		// This helps with debugging and is enforced in OCP, see https://issues.redhat.com/browse/OCPBUGS-33170.
+		container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 	}
 
 	if err := scheme.Convert(deployment, obj, nil); err != nil {

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/munnerz/goautoneg
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240304144039-3218c094afd5
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b
 ## explicit; go 1.18
 github.com/openshift/cluster-capi-operator/manifests-gen
 # github.com/pelletier/go-toml/v2 v2.1.0


### PR DESCRIPTION
In 4.17, we are enforcing this value for all OpenShift containers via tests, link in bug comment. This helps with debugging to ensure we have logs available.

Ref: https://github.com/openshift/cluster-capi-operator/pull/172