### PR TITLE
ART-12521: update go mod dependency for konflux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ coverage.*
 .env
 envfile
 
+!vendor/github.com/emicklei/go-restful/v3/coverage.sh
+!vendor/github.com/subosito/gotenv/.env
+
 # kubeconfigs
 kind.kubeconfig
 minikube.kubeconfig

--- a/vendor/github.com/emicklei/go-restful/v3/coverage.sh
+++ b/vendor/github.com/emicklei/go-restful/v3/coverage.sh
@@ -1,0 +1,2 @@
+go test -coverprofile=coverage.out
+go tool cover -html=coverage.out

--- a/vendor/github.com/subosito/gotenv/.env
+++ b/vendor/github.com/subosito/gotenv/.env
@@ -1,0 +1,1 @@
+HELLO=world


### PR DESCRIPTION
Image build was failing on Konflux due to missing go mod dependencies.

```
2025-04-04 17:30:06,588 ERROR vendor directory changed after vendoring:
A	vendor/github.com/emicklei/go-restful/v3/coverage.sh
A	vendor/github.com/subosito/gotenv/.env
2025-04-04 17:30:08,935 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
```

Konflux ignores .gitignore files since its a possible security gap. 