### PR TITLE
OCPBUGS-56962: [release-4.19] Update manifests to remove dependency on admissionregistration v1beta1

### DIFF
--- a/openshift/infrastructure-components-openshift.yaml
+++ b/openshift/infrastructure-components-openshift.yaml
@@ -3693,7 +3693,7 @@ spec:
   selector:
     cluster.x-k8s.io/provider: infrastructure-gcp
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-cluster-api-protect-gcpcluster
@@ -3717,7 +3717,7 @@ spec:
     message: InfraCluster resources with metadata.name corresponding to the cluster
       infrastructureName cannot be deleted.
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: openshift-cluster-api-protect-gcpcluster

--- a/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-gcp.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-gcp.yaml
@@ -3695,7 +3695,7 @@ data:
       selector:
         cluster.x-k8s.io/provider: infrastructure-gcp
     ---
-    apiVersion: admissionregistration.k8s.io/v1beta1
+    apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingAdmissionPolicy
     metadata:
       name: openshift-cluster-api-protect-gcpcluster
@@ -3719,7 +3719,7 @@ data:
         message: InfraCluster resources with metadata.name corresponding to the cluster
           infrastructureName cannot be deleted.
     ---
-    apiVersion: admissionregistration.k8s.io/v1beta1
+    apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingAdmissionPolicyBinding
     metadata:
       name: openshift-cluster-api-protect-gcpcluster

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -4,7 +4,7 @@ go 1.22.7
 
 toolchain go1.23.6
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250319005016-c5a5e4ef8e20
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250529172926-ee69183571b5
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -118,6 +118,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250319005016-c5a5e4ef8e20 h1:InKgBPzU4anIcTnzQEAD5jzWQVbYFqSAStfbw82eIRs=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250319005016-c5a5e4ef8e20/go.mod h1:4+57eaR8Pv6wpuhZhmImQOixmRMUgVN/ugesZddG8xc=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250529172926-ee69183571b5 h1:Eg8k6UeP9Ejj9UdPLlBWY2L0pwEtdEXm0XlLE5tbUik=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250529172926-ee69183571b5/go.mod h1:4+57eaR8Pv6wpuhZhmImQOixmRMUgVN/ugesZddG8xc=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
@@ -341,7 +341,7 @@ func mergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
 func addInfraClusterProtectionPolicy(objs []unstructured.Unstructured, providerName string) []unstructured.Unstructured {
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "admissionregistration.k8s.io/v1beta1",
+			"apiVersion": "admissionregistration.k8s.io/v1",
 			"kind":       "ValidatingAdmissionPolicy",
 			"metadata": map[string]interface{}{
 				"name": "openshift-cluster-api-protect-" + providerName + "cluster",
@@ -374,7 +374,7 @@ func addInfraClusterProtectionPolicy(objs []unstructured.Unstructured, providerN
 
 	binding := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "admissionregistration.k8s.io/v1beta1",
+			"apiVersion": "admissionregistration.k8s.io/v1",
 			"kind":       "ValidatingAdmissionPolicyBinding",
 			"metadata": map[string]interface{}{
 				"name": "openshift-cluster-api-protect-" + providerName + "cluster",

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/munnerz/goautoneg
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250319005016-c5a5e4ef8e20
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20250529172926-ee69183571b5
 ## explicit; go 1.22.7
 github.com/openshift/cluster-capi-operator/manifests-gen
 # github.com/pelletier/go-toml/v2 v2.2.2


### PR DESCRIPTION


This PR updates manifests gen and then regenerates the manifests to pick up switch from v1beta1 to v1 for the admissionregistration group on the ValidatingAdmissionPolicy{Binding}s we use
