### PR TITLE
NO-JIRA: openshift: rename manager binary

### DIFF
--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -4,16 +4,16 @@ WORKDIR /build
 COPY . .
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=${GOOS} GOPROXY=${GOPROXY} go build \
   -ldflags="-w -s -X 'main.version=${VERSION}'" \
-  -o=cluster-api-provider-gcp-controller-manager \
+  -o=manager \
   main.go
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 
 LABEL description="Cluster API Provider GCP Controller Manager"
 
-COPY --from=builder /build/cluster-api-provider-gcp-controller-manager /bin/cluster-api-provider-gcp-controller-manager
+COPY --from=builder /build/manager /manager
 COPY --from=builder /build/openshift/manifests /manifests
 
-ENTRYPOINT [ "/bin/cluster-api-provider-gcp-controller-manager" ]
+ENTRYPOINT [ "/manager" ]
 
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
capiinstaller drop manager replacement
Needs to be green button merged (a.k.a. "flag day" ed), together with:
- https://github.com/openshift/cluster-capi-operator/pull/410
- https://github.com/openshift/cluster-api/pull/252
- https://github.com/openshift/cluster-api-provider-aws/pull/581
- https://github.com/openshift/cluster-api-provider-gcp/pull/252
- https://github.com/openshift/cluster-api-provider-ibmcloud/pull/132