### PR TITLE
OCPBUGS-78278: [release-4.18] update go mod dependency for konflux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ coverage.*
 .env
 envfile
 
+!vendor/github.com/emicklei/go-restful/v3/coverage.sh
+!vendor/github.com/subosito/gotenv/.env
+
 # kubeconfigs
 kind.kubeconfig
 minikube.kubeconfig

--- a/vendor/github.com/emicklei/go-restful/v3/coverage.sh
+++ b/vendor/github.com/emicklei/go-restful/v3/coverage.sh
@@ -1,0 +1,2 @@
+go test -coverprofile=coverage.out
+go tool cover -html=coverage.out

--- a/vendor/github.com/subosito/gotenv/.env
+++ b/vendor/github.com/subosito/gotenv/.env
@@ -1,0 +1,1 @@
+HELLO=world


### PR DESCRIPTION
cherry pick of 6f4319a5edbdf78a3265ca214383bd0376e78846, https://github.com/openshift/cluster-api-provider-gcp/pull/240

this is needed for the hermetic migration in konflux, to fix the following error:

```
Error: PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
  Please try running `go mod vendor` and committing the changes.
  Note that you may need to `git add --force` ignored files in the vendor/ dir.
```