### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -4816,6 +4816,8 @@ spec:
         - --diagnostics-address=${CAPG_DIAGNOSTICS_ADDRESS:=:8443}
         - --insecure-diagnostics=${CAPG_INSECURE_DIAGNOSTICS:=false}
         - --v=${CAPG_LOGLEVEL:=0}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /home/.gcp/service_account.json

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -14,3 +14,15 @@ images:
 
 patches:
 - path: ./patches/credentials.yaml
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+- target:
+    kind: Deployment
+    name: capg-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controller manager now supports configurable TLS settings: you can set the TLS minimum version and the TLS cipher suites via environment variables (TLS_MIN_VERSION and TLS_CIPHER_SUITES), which are passed as launch arguments. No other runtime flags, pod specs, or logging/diagnostics were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->