### PR TITLE
NO-JIRA: manifests-gen: scope provider webhooks to capi namespace

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -4914,6 +4914,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.gcpcluster.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -4935,6 +4938,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.gcpclustertemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -4956,6 +4962,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.gcpmachine.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -4977,6 +4986,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.gcpmachinetemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -4997,6 +5009,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcluster
   failurePolicy: Fail
   name: mgcpmanagedcluster.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5017,6 +5032,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcontrolplane
   failurePolicy: Fail
   name: mgcpmanagedcontrolplane.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5038,6 +5056,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: mgcpmanagedcontrolplanetemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5058,6 +5079,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedmachinepool
   failurePolicy: Fail
   name: mgcpmanagedmachinepool.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5078,6 +5102,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedmachinepooltemplate
   failurePolicy: Fail
   name: mgcpmanagedmachinepooltemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5109,6 +5136,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.gcpcluster.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5130,6 +5160,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.gcpclustertemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5151,6 +5184,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.gcpmachine.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5172,6 +5208,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.gcpmachinetemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5192,6 +5231,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcluster
   failurePolicy: Fail
   name: vgcpmanagedcluster.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5212,6 +5254,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedclustertemplate
   failurePolicy: Fail
   name: vgcpmanagedclustertemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5231,6 +5276,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcontrolplane
   failurePolicy: Fail
   name: vgcpmanagedcontrolplane.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5252,6 +5300,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vgcpmanagedcontrolplanetemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -5272,6 +5323,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedmachinepool
   failurePolicy: Fail
   name: vgcpmanagedmachinepool.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.25.0
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -95,8 +95,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80 h1:r0S/yoZAI0iWo1JvoIijaIgWGWf/izg4WiV7Wrtz16k=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c h1:brDtyXDZ8M/6KpJ9rsXQ3KKGawgN4TeiD4NpjFvu3V4=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c h1:mCbdsqRsXvIw22zy5c07zmFpaE/ng6ehx0Pq399UM3w=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
@@ -3,6 +3,31 @@ kind: Component
 
 namespace: openshift-cluster-api
 
+resources:
+  - webhook-namespace-selector.yaml
+
+# Scope all provider webhooks to the openshift-cluster-api namespace.
+# This prevents webhooks from intercepting requests in other namespaces,
+# which would fail on unsupported platforms where the webhook server is not running.
+replacements:
+  - source:
+      kind: ConfigMap
+      name: webhook-namespace-selector
+      fieldPath: data.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+
 patches:
 
 # Retain Secrets internally for reference tracking, but don't emit them
@@ -14,6 +39,7 @@ patches:
     metadata:
       name: __ignored__
       annotations:
+        # Marks this resource as local-only so kustomize excludes it from the final output.
         config.kubernetes.io/local-config: "true"
 
 # Set OpenShift pod annotations on all Deployments' pod templates.

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
@@ -1,0 +1,14 @@
+# This ConfigMap is a kustomize workaround: replacements need a concrete source resource
+# to read a value from, but there is no real resource that holds the target namespace.
+# This ConfigMap acts as that source, providing the namespace value to inject into webhook
+# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# It is marked as local-config so kustomize never emits it in the final output.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webhook-namespace-selector
+  annotations:
+    # Marks this resource as local-only so kustomize excludes it from the final output.
+    config.kubernetes.io/local-config: "true"
+data:
+  namespace: openshift-cluster-api

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/opencontainers/go-digest
 # github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80
 ## explicit; go 1.25.0
 github.com/openshift/api/config/v1
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 ## explicit; go 1.25.0
 github.com/openshift/cluster-capi-operator/manifests-gen
 github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata


### PR DESCRIPTION
Bumps `manifests-gen` to include webhook namespace scoping, which adds a `namespaceSelector` to all provider webhooks restricting them to the `openshift-cluster-api` namespace.

This prevents webhooks from intercepting requests in other namespaces, which would fail on unsupported platforms where the webhook server is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple webhook configurations to restrict admission control operations exclusively to the openshift-cluster-api namespace. This ensures all mutation and validation webhooks for GCP-related cluster resources, machine templates, managed clusters, and managed machine pools operate only within the designated cluster API namespace.
  * Updated manifests-gen dependency to a newer version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->